### PR TITLE
define output variables when parser reads from stdin

### DIFF
--- a/chuffed/flatzinc/parser.tab.cpp
+++ b/chuffed/flatzinc/parser.tab.cpp
@@ -407,6 +407,7 @@ namespace FlatZinc {
     // yydebug = 1;
     yyparse(&pp);
     FlatZinc::s->output = pp.getOutput();
+    FlatZinc::s->setOutput();
     
     if (pp.yyscanner)
       yylex_destroy(pp.yyscanner);

--- a/chuffed/flatzinc/parser.yxx
+++ b/chuffed/flatzinc/parser.yxx
@@ -366,6 +366,7 @@ namespace FlatZinc {
         // yydebug = 1;
         yyparse(&pp);
         FlatZinc::s->output = pp.getOutput();
+        FlatZinc::s->setOutput();
         
         if (pp.yyscanner)
             yylex_destroy(pp.yyscanner);


### PR DESCRIPTION
`fzn-chuffed` with option `-a` breaks if we provide flatzinc input from stdin, i.e., if we invoke the solving pipeline as follows

     cat model.mzn | mzn2fzn --globals-dir chuffed --input-from-stdin --no-output-ozn --output-to-stdout | fzn-chuffed -a
     [...]
     /media/psf/Home/Programming/MiniZinc/libminizinc-deploy/ide/linux/build-chuffed-64/chuffed/chuffed/core/engine.cpp:419: Not yet supported

the following assertion from https://github.com/chuffed/chuffed/blob/master/chuffed/core/engine.cpp#L419 aborts the execution:

     if (outputs.size() == 0) NOT_SUPPORTED;

With flatzinc file input (`fzn-chuffed -a <file>.fzn`) or invoking above solving pipeline without option `-a`, `fzn-chuffed` works as expected.

I could track down the problem to function `FlatZinc::solve(std::istream& is, std::ostream& err)` in `chuffed/flatzinc/parser.yxx` (https://github.com/chuffed/chuffed/blob/develop/chuffed/flatzinc/parser.yxx#L359), which does not call `FlatZinc::s->setOutput()` and therefore does not define output variables when the parser reads its input from a `std::istream`. In contrast, function `FlatZinc::solve(const std::string& filename, std::ostream& err)` does call `FlatZinc::s->setOutput()` and therefore `fzn-chuffed` works with option `-a` when the input comes from a file.

This pull request adds the missing call to `FlatZinc::s->setOutput()` in function `FlatZinc::solve(std::istream& is, std::ostream& err)`.
