### PR TITLE
FlatZinc: Add support for integer half-reification constraints

### DIFF
--- a/chuffed/flatzinc/mznlib/redefinitions.mzn
+++ b/chuffed/flatzinc/mznlib/redefinitions.mzn
@@ -84,3 +84,9 @@ predicate array_bool_xor(array[int] of var bool: bs) =
 predicate int_mod(var int: x, var int: y, var int: z) =
   x=(x div y)*y+z;
 
+predicate int_eq_imp(var int: a, var int: b, var bool: r);
+predicate int_ne_imp(var int: a, var int: b, var bool: r);
+predicate int_ge_imp(var int: a, var int: b, var bool: r);
+predicate int_gt_imp(var int: a, var int: b, var bool: r);
+predicate int_le_imp(var int: a, var int: b, var bool: r);
+predicate int_lt_imp(var int: a, var int: b, var bool: r);

--- a/chuffed/flatzinc/registry.cpp
+++ b/chuffed/flatzinc/registry.cpp
@@ -192,6 +192,42 @@ namespace FlatZinc {
 			p_int_CMP(IRT_LT, ce, ann);
 		}
 
+		void p_int_CMP_imp(IntRelType irt, const ConExpr& ce, AST::Node* ann) {
+			if (ce[2]->isBool()) {
+				if (ce[2]->getBool()) {
+					p_int_CMP(irt, ce, ann);
+				}
+				return;
+			}
+			if (ce[0]->isIntVar()) {
+				if (ce[1]->isIntVar()) {
+					int_rel_half_reif(getIntVar(ce[0]), irt, getIntVar(ce[1]), getBoolVar(ce[2]));
+				} else {
+					int_rel_half_reif(getIntVar(ce[0]), irt, ce[1]->getInt(), getBoolVar(ce[2]));
+				}
+			} else {
+				int_rel_half_reif(getIntVar(ce[1]), -irt, ce[0]->getInt(), getBoolVar(ce[2]));
+			}
+		}
+		void p_int_eq_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_EQ, ce, ann);
+		}
+		void p_int_ne_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_NE, ce, ann);
+		}
+		void p_int_ge_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_GE, ce, ann);
+		}
+		void p_int_gt_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_GT, ce, ann);
+		}
+		void p_int_le_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_LE, ce, ann);
+		}
+		void p_int_lt_imp(const ConExpr& ce, AST::Node* ann) {
+		  p_int_CMP_imp(IRT_LT, ce, ann);
+		}
+
 		void p_int_CMP_reif(IntRelType irt, const ConExpr& ce, AST::Node* ann) {
 			if (ce[2]->isBool()) {
 				if (ce[2]->getBool()) {
@@ -995,6 +1031,12 @@ namespace FlatZinc {
 				registry().add("int_gt", &p_int_gt);
 				registry().add("int_le", &p_int_le);
 				registry().add("int_lt", &p_int_lt);
+				registry().add("int_eq_imp", &p_int_eq_imp);
+				registry().add("int_ne_imp", &p_int_ne_imp);
+				registry().add("int_ge_imp", &p_int_ge_imp);
+				registry().add("int_gt_imp", &p_int_gt_imp);
+				registry().add("int_le_imp", &p_int_le_imp);
+				registry().add("int_lt_imp", &p_int_lt_imp);
 				registry().add("int_eq_reif", &p_int_eq_reif);
 				registry().add("int_ne_reif", &p_int_ne_reif);
 				registry().add("int_ge_reif", &p_int_ge_reif);

--- a/chuffed/primitives/binary.cpp
+++ b/chuffed/primitives/binary.cpp
@@ -395,9 +395,9 @@ void int_rel_half_reif_real(IntVar* x, IntRelType t, int c, BoolView r) {
 		}
 		break;
 		case IRT_LE: bool_rel(b2, BRT_OR, ~r); break;
-		case IRT_LT: bool_rel(~b2, BRT_OR, ~r); break;
+		case IRT_LT: bool_rel(~b1, BRT_OR, ~r); break;
 		case IRT_GE: bool_rel(b1, BRT_OR, ~r); break;
-		case IRT_GT: bool_rel(~b1, BRT_OR, ~r); break;
+		case IRT_GT: bool_rel(~b2, BRT_OR, ~r); break;
 		default: NEVER;
 	}
 }

--- a/chuffed/primitives/binary.cpp
+++ b/chuffed/primitives/binary.cpp
@@ -202,6 +202,7 @@ struct IRR {
 };
 
 vec<IRR> ircs;
+vec<IRR> ihrcs;
 
 
 //-----
@@ -313,6 +314,10 @@ void int_rel_reif(IntVar* x, IntRelType t, IntVar* y, BoolView r, int c) {
 
 // x rel y + c <- r
 
+void int_rel_half_reif(IntVar* x, IntRelType t, int c, BoolView r) {
+	ihrcs.push(IRR(x, t, c, r));
+}
+
 void int_rel_half_reif(IntVar* x, IntRelType t, IntVar* y, BoolView r, int c) {
 	switch (t) {
 		case IRT_EQ:
@@ -365,11 +370,45 @@ void int_rel_reif_real(IntVar* x, IntRelType t, int c, BoolView r) {
 		case IRT_GT: bool_rel(b2, BRT_EQ, ~r); break;
 		default: NEVER;
 	}
-} 
+}
+
+void int_rel_half_reif_real(IntVar* x, IntRelType t, int c, BoolView r) {
+	if (r.isFalse()) {
+		return;
+	}
+	if (r.isTrue() && t == IRT_NE && x->getType() == INT_VAR_EL) {
+		TL_SET(x, remVal, c); return;
+	}
+	if (x->getType() == INT_VAR) {
+		assert(!so.lazy);
+		IntVar* v = getConstant(c);
+		int_rel_half_reif(x, t, v, r);
+		return;
+	}
+	BoolView b1(x->getLit(c,2)), b2(x->getLit(c,3));
+	switch (t) {
+		case IRT_EQ: bool_rel(b2, BRT_OR, ~r); bool_rel(b1, BRT_OR, ~r); break;
+		case IRT_NE:
+		{
+			vec<Lit> ps1; ps1.push(~b1); ps1.push(~b2); ps1.push(~r); sat.addClause(ps1);
+			vec<Lit> ps2; ps2.push(b1); ps2.push(b2); ps2.push(~r); sat.addClause(ps2);
+		}
+		break;
+		case IRT_LE: bool_rel(b2, BRT_OR, ~r); break;
+		case IRT_LT: bool_rel(~b2, BRT_OR, ~r); break;
+		case IRT_GE: bool_rel(b1, BRT_OR, ~r); break;
+		case IRT_GT: bool_rel(~b1, BRT_OR, ~r); break;
+		default: NEVER;
+	}
+}
 
 void process_ircs() {
 	for (int i = 0; i < ircs.size(); i++) {
 		int_rel_reif_real(ircs[i].x, ircs[i].t, ircs[i].c, ircs[i].r);
 	}
 	ircs.clear(true);
+	for (int j = 0; j < ihrcs.size(); ++j) {
+		int_rel_half_reif_real(ihrcs[j].x, ihrcs[j].t, ihrcs[j].c, ihrcs[j].r);
+	}
+	ihrcs.clear(true);
 }

--- a/chuffed/primitives/primitives.h
+++ b/chuffed/primitives/primitives.h
@@ -85,9 +85,11 @@ void int_rel(IntVar* x, IntRelType t, int c);
 // x rel y + c <-> r
 void int_rel_reif(IntVar* x, IntRelType t, IntVar* y, BoolView r, int c = 0);
 // x rel y + c <- r
-void int_rel_half_reif(IntVar* a, IntRelType t, IntVar* b, BoolView r, int c);
+void int_rel_half_reif(IntVar* a, IntRelType t, IntVar* b, BoolView r, int c = 0);
 // x rel c <-> r
 void int_rel_reif(IntVar* a, IntRelType t, int c, BoolView r);
+// x rel c <- r
+void int_rel_half_reif(IntVar* a, IntRelType t, int c, BoolView r);
 
 // linear.c
 


### PR DESCRIPTION
Chuffed already has support for integer half-refied constraints; however, you cannot access these from FlatZinc. This PR adds the following predicates to the registry:
```
predicate int_eq_imp(var int: a, var int: b, var bool: r);
predicate int_ne_imp(var int: a, var int: b, var bool: r);
predicate int_ge_imp(var int: a, var int: b, var bool: r);
predicate int_gt_imp(var int: a, var int: b, var bool: r);
predicate int_le_imp(var int: a, var int: b, var bool: r);
predicate int_lt_imp(var int: a, var int: b, var bool: r);
```

The naming of these predicates is consistent with the naming of the half-refied predicates in Gecode.

Like fully reified constraints partially known half-reified constraints can make holes within the domain of a variable. It therefore follows the same steps as reified constraints, storing the constraints temporarily and calling `int_rel_half_reif_real` after initialisation, when one of the values of the constraints is known.