### PR TITLE
Restart Strategies

### DIFF
--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -700,12 +700,7 @@ RESULT Engine::search(const std::string& problemLabel) {
                 if (so.verbosity >= 2)
                     std::cerr << "restarting due to number of conflicts\n";
                 starts++;
-                if (so.restart_type == CHUFFED_DEFAULT) {
-                    //TODO: Why does default add instead of replace?
-                    nof_conflicts += getRestartLimit(starts);
-                } else {
-                    nof_conflicts = getRestartLimit(starts);
-                }
+                nof_conflicts += getRestartLimit(starts);
                 sat.btToLevel(0);
                 restartCount++;
                 nodepath.resize(0);

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -437,6 +437,8 @@ void Engine::blockCurrentSol() {
 
 unsigned int Engine::getRestartLimit(unsigned int i) {
     switch (so.restart_type) {
+        case NONE:
+            CHUFFED_ERROR("A restart occurred while using search without restarts");
         case CONSTANT:
             return so.restart_scale;
         case LINEAR:
@@ -482,7 +484,7 @@ void Engine::toggleVSIDS() {
 
 RESULT Engine::search(const std::string& problemLabel) {
     unsigned int starts = 0;
-    unsigned int nof_conflicts = so.restart_scale;
+    unsigned int nof_conflicts = (so.restart_type == NONE) ? UINT_MAX : so.restart_scale;
     unsigned int conflictC = 0;
 
     if (so.print_variable_list) {

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -718,7 +718,7 @@ RESULT Engine::search(const std::string& problemLabel) {
 #endif
 
                 sat.confl = NULL;
-                if (so.lazy && so.toggle_vsids && (starts % 2 == 0)) toggleVSIDS();
+                if (so.lazy && so.toggle_vsids && (starts % 2 == 1)) toggleVSIDS();
                 continue;
             }
             

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -438,6 +438,9 @@ void Engine::blockCurrentSol() {
 unsigned int Engine::getRestartLimit(unsigned int i) {
     switch (so.restart_type) {
         case NONE:
+            if (i > 1) {
+                CHUFFED_ERROR("A restart occurred while using search without restarts");
+            }
             return UINT_MAX;
         case CONSTANT:
             return so.restart_scale;

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -438,7 +438,7 @@ void Engine::blockCurrentSol() {
 unsigned int Engine::getRestartLimit(unsigned int i) {
     switch (so.restart_type) {
         case NONE:
-            CHUFFED_ERROR("A restart occurred while using search without restarts");
+            return UINT_MAX;
         case CONSTANT:
             return so.restart_scale;
         case LINEAR:
@@ -483,8 +483,8 @@ void Engine::toggleVSIDS() {
 }
 
 RESULT Engine::search(const std::string& problemLabel) {
-    unsigned int starts = 0;
-    unsigned int nof_conflicts = (so.restart_type == NONE) ? UINT_MAX : so.restart_scale;
+    unsigned int starts = 1;
+    unsigned int nof_conflicts = getRestartLimit(starts);
     unsigned int conflictC = 0;
 
     if (so.print_variable_list) {

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -79,7 +79,7 @@ private:
     void topLevelCleanUp();
     void simplifyDB();
     void blockCurrentSol();
-    int  getRestartLimit(int starts);
+    unsigned int getRestartLimit(unsigned int i); // Return the restart limit for restart i
     void toggleVSIDS();
 
 public:

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -14,8 +14,11 @@ Options::Options() :
 	, verbosity(0)
 	, print_sol(true)
 	, restart_scale(1000000000)
+    , restart_scale_override(true)
     , restart_base(1.5)
+    , restart_base_override(true)
     , restart_type(CHUFFED_DEFAULT)
+    , restart_type_override(true)
 
 	, toggle_vsids(false)
 	, branch_random(false)
@@ -475,8 +478,10 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
         std::cerr << argv[0] << ": Unknown restart strategy " << stringBuffer
                   << ". Chuffed will use its default strategy.\n";
       }
+      so.restart_type_override = false;
     } else if (cop.get("--restart-scale", &intBuffer)) {
       so.restart_scale = static_cast<unsigned int>(intBuffer);
+      so.restart_scale_override = false;
     } else if (cop.get("--restart-base", &stringBuffer)) {
       // TODO: Remove warning when appropriate
       std::cerr << "WARNING: the --restart-base flag has recently been changed."
@@ -485,6 +490,7 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       if (so.restart_base < 1.0) {
         CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");
       }
+      so.restart_base_override = false;
     } else if (cop.getBool("--toggle-vsids", boolBuffer)) {
       so.toggle_vsids = boolBuffer;
     } else if (cop.getBool("--branch-random", boolBuffer)) {

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -477,6 +477,9 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.restart_scale = static_cast<unsigned int>(intBuffer);
     } else if (cop.get("--restart-base", &stringBuffer)) {
       so.restart_base = stod(stringBuffer);
+      if (so.restart_base < 1.0) {
+        CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");
+      }
     } else if (cop.getBool("--toggle-vsids", boolBuffer)) {
       so.toggle_vsids = boolBuffer;
     } else if (cop.getBool("--branch-random", boolBuffer)) {

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -460,15 +460,15 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.print_sol = boolBuffer;
     } else if (cop.get("--restart", &stringBuffer)) {
       if (stringBuffer == "chuffed") {
-        so.restart_base = CHUFFED_DEFAULT;
+        so.restart_type = CHUFFED_DEFAULT;
       } else if (stringBuffer == "constant") {
-        so.restart_base = CONSTANT;
+        so.restart_type = CONSTANT;
       } else if (stringBuffer == "linear") {
-        so.restart_base = LINEAR;
+        so.restart_type = LINEAR;
       } else if (stringBuffer == "luby") {
-        so.restart_base = LUBY;
+        so.restart_type = LUBY;
       } else if (stringBuffer == "geometric") {
-        so.restart_base = GEOMETRIC;
+        so.restart_type = GEOMETRIC;
       } else {
         std::cerr << argv[0] << ": Unknown restart strategy " << stringBuffer
                   << ". Chuffed will use its default strategy.\n";

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -478,6 +478,9 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
     } else if (cop.get("--restart-scale", &intBuffer)) {
       so.restart_scale = static_cast<unsigned int>(intBuffer);
     } else if (cop.get("--restart-base", &stringBuffer)) {
+      // TODO: Remove warning when appropriate
+      std::cerr << "WARNING: the --restart-base flag has recently been changed."
+                << "The old behaviour of \"restart base\" is now implemented by --restart-scale.";
       so.restart_base = stod(stringBuffer);
       if (so.restart_base < 1.0) {
         CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -13,7 +13,7 @@ Options::Options() :
 	, rnd_seed(0)
 	, verbosity(0)
 	, print_sol(true)
-	, restart_base(1000000000)
+	, restart_scale(1000000000)
 
 	, toggle_vsids(false)
 	, branch_random(false)
@@ -279,7 +279,7 @@ void printLongHelp(int& argc, char**& argv, const std::string& fileExt) {
   "  --vsids [on|off], --no-vsids\n"
   "     Use activity-based search on the Boolean variables (default " << (def.vsids ? "on" : "off") << ").\n"
   "  --restart-base <n>\n"
-  "     Number of conflicts after which the search restarts (default " << def.restart_base << ").\n"
+  "     Number of conflicts after which the search restarts (default " << def.restart_scale << ").\n"
   "  --toggle-vsids [on|off], --no-toggle-vsids\n"
   "     Alternate search between user-specified and activity-based one when the\n"
   "     search is restarted. Starts by the user-specified search. Default restart\n"
@@ -453,7 +453,7 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
     } else if (cop.getBool("--print-sol", boolBuffer)) {
       so.print_sol = boolBuffer;
     } else if (cop.get("--restart-base", &intBuffer)) {
-      so.restart_base = intBuffer;
+      so.restart_scale = intBuffer;
     } else if (cop.getBool("--toggle-vsids", boolBuffer)) {
       so.toggle_vsids = boolBuffer;
     } else if (cop.getBool("--branch-random", boolBuffer)) {
@@ -560,7 +560,7 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.nof_solutions = 0;
     } else if (cop.get("-f")) {
       so.toggle_vsids = true;
-      so.restart_base = 100;
+      so.restart_scale = 100;
     } else if (cop.get("-p", &intBuffer)) {
       so.parallel = true;
       so.num_cores = intBuffer;

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -14,6 +14,8 @@ Options::Options() :
 	, verbosity(0)
 	, print_sol(true)
 	, restart_scale(1000000000)
+    , restart_base(1.5)
+    , restart_type(CHUFFED_DEFAULT)
 
 	, toggle_vsids(false)
 	, branch_random(false)
@@ -278,8 +280,12 @@ void printLongHelp(int& argc, char**& argv, const std::string& fileExt) {
   "More Search Options:\n"
   "  --vsids [on|off], --no-vsids\n"
   "     Use activity-based search on the Boolean variables (default " << (def.vsids ? "on" : "off") << ").\n"
+  "  --restart [chuffed|constant|linear|luby|geometric]\n"
+  "     Restart sequence type (default chuffed).\n"
+  "  --restart-scale <n>\n"
+  "     Scale factor for restart sequence (default " << def.restart_scale << ").\n"
   "  --restart-base <n>\n"
-  "     Number of conflicts after which the search restarts (default " << def.restart_scale << ").\n"
+  "     Base for geometric restart sequence (default " << def.restart_base << ").\n"
   "  --toggle-vsids [on|off], --no-toggle-vsids\n"
   "     Alternate search between user-specified and activity-based one when the\n"
   "     search is restarted. Starts by the user-specified search. Default restart\n"
@@ -452,8 +458,25 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.verbosity = intBuffer;
     } else if (cop.getBool("--print-sol", boolBuffer)) {
       so.print_sol = boolBuffer;
-    } else if (cop.get("--restart-base", &intBuffer)) {
-      so.restart_scale = intBuffer;
+    } else if (cop.get("--restart", &stringBuffer)) {
+      if (stringBuffer == "chuffed") {
+        so.restart_base = CHUFFED_DEFAULT;
+      } else if (stringBuffer == "constant") {
+        so.restart_base = CONSTANT;
+      } else if (stringBuffer == "linear") {
+        so.restart_base = LINEAR;
+      } else if (stringBuffer == "luby") {
+        so.restart_base = LUBY;
+      } else if (stringBuffer == "geometric") {
+        so.restart_base = GEOMETRIC;
+      } else {
+        std::cerr << argv[0] << ": Unknown restart strategy " << stringBuffer
+                  << ". Chuffed will use its default strategy.\n";
+      }
+    } else if (cop.get("--restart-scale", &intBuffer)) {
+      so.restart_scale = static_cast<unsigned int>(intBuffer);
+    } else if (cop.get("--restart-base", &stringBuffer)) {
+      so.restart_base = stod(stringBuffer);
     } else if (cop.getBool("--toggle-vsids", boolBuffer)) {
       so.toggle_vsids = boolBuffer;
     } else if (cop.getBool("--branch-random", boolBuffer)) {

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -280,7 +280,7 @@ void printLongHelp(int& argc, char**& argv, const std::string& fileExt) {
   "More Search Options:\n"
   "  --vsids [on|off], --no-vsids\n"
   "     Use activity-based search on the Boolean variables (default " << (def.vsids ? "on" : "off") << ").\n"
-  "  --restart [chuffed|constant|linear|luby|geometric]\n"
+  "  --restart [chuffed|none|constant|linear|luby|geometric]\n"
   "     Restart sequence type (default chuffed).\n"
   "  --restart-scale <n>\n"
   "     Scale factor for restart sequence (default " << def.restart_scale << ").\n"
@@ -461,6 +461,8 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
     } else if (cop.get("--restart", &stringBuffer)) {
       if (stringBuffer == "chuffed") {
         so.restart_type = CHUFFED_DEFAULT;
+      } else if (stringBuffer == "none") {
+        so.restart_type = NONE;
       } else if (stringBuffer == "constant") {
         so.restart_type = CONSTANT;
       } else if (stringBuffer == "linear") {

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -12,6 +12,8 @@
 
 #define DEBUG_VERBOSE 0
 
+enum RestartType { CHUFFED_DEFAULT, CONSTANT, LINEAR, LUBY, GEOMETRIC};
+
 class Options {
 public:
 	// Solver options
@@ -20,7 +22,9 @@ public:
 	int rnd_seed;                    // Random seed
 	int verbosity;                   // Verbosity
 	bool print_sol;                  // Print solutions
-	int restart_base;                // How many conflicts before restart
+	unsigned int restart_scale;      // How many conflicts before restart
+	float restart_base;              // How is the restart limit scaled (linear, geometric)
+	RestartType restart_type;        // How is the restart limit computed
 
 	// Search options
 	bool toggle_vsids;               // Alternate between search ann/vsids

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -23,8 +23,11 @@ public:
 	int verbosity;                   // Verbosity
 	bool print_sol;                  // Print solutions
 	unsigned int restart_scale;      // How many conflicts before restart
-	double restart_base;              // How is the restart limit scaled (linear, geometric)
+	bool restart_scale_override;     // Restart scale set from CLI
+	double restart_base;             // How is the restart limit scaled (geometric)
+	bool restart_base_override;      // Restart base set from CLI
 	RestartType restart_type;        // How is the restart limit computed
+	bool restart_type_override;      // Restart type set from CLI
 
 	// Search options
 	bool toggle_vsids;               // Alternate between search ann/vsids

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -12,7 +12,7 @@
 
 #define DEBUG_VERBOSE 0
 
-enum RestartType { CHUFFED_DEFAULT, CONSTANT, LINEAR, LUBY, GEOMETRIC};
+enum RestartType { CHUFFED_DEFAULT, NONE, CONSTANT, LINEAR, LUBY, GEOMETRIC};
 
 class Options {
 public:

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -23,7 +23,7 @@ public:
 	int verbosity;                   // Verbosity
 	bool print_sol;                  // Print solutions
 	unsigned int restart_scale;      // How many conflicts before restart
-	float restart_base;              // How is the restart limit scaled (linear, geometric)
+	double restart_base;              // How is the restart limit scaled (linear, geometric)
 	RestartType restart_type;        // How is the restart limit computed
 
 	// Search options

--- a/chuffed/flatzinc/ast.h
+++ b/chuffed/flatzinc/ast.h
@@ -85,6 +85,8 @@ namespace FlatZinc { namespace AST {
     int getInt(void);
     /// Cast this node to a Boolean node
     bool getBool(void);
+    /// Cast this node to a Float node
+    double getFloat(void);
     /// Cast this node to a set literal node
     SetLit *getSet(void);
     
@@ -389,6 +391,12 @@ namespace FlatZinc { namespace AST {
     if (BoolLit* a = dynamic_cast<BoolLit*>(this))
       return a->b;
     throw TypeError("bool literal expected");
+  }
+  inline double
+  Node::getFloat(void) {
+    if (FloatLit* a = dynamic_cast<FloatLit*>(this))
+      return a->d;
+    throw TypeError("float literal expected");
   }
   inline SetLit*
   Node::getSet(void) {

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -343,29 +343,29 @@ namespace FlatZinc {
     void FlatZincSpace::parseSolveAnn(AST::Array* ann, BranchGroup* branching, int & nbNonEmptySearchAnnotations) {
         if (ann) {
             for (unsigned int i = 0; i < ann->a.size(); i++) {
-                if (ann->a[i]->isCall("restart_none")) {
+                if (ann->a[i]->isCall("restart_none") && so.restart_type_override) {
                     so.restart_type = NONE;
                 } else if (ann->a[i]->isCall("restart_constant")) {
                     AST::Call* call = ann->a[i]->getCall("restart_constant");
-                    so.restart_type = CONSTANT;
-                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                    if (so.restart_type_override) { so.restart_type = CONSTANT; }
+                    if (so.restart_scale_override) { so.restart_scale = static_cast<unsigned int>(call->args->getInt()); }
                 } else if (ann->a[i]->isCall("restart_linear")) {
                     AST::Call* call = ann->a[i]->getCall("restart_linear");
-                    so.restart_type = LINEAR;
-                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                    if (so.restart_type_override) { so.restart_type = LINEAR; }
+                    if (so.restart_scale_override) { so.restart_scale = static_cast<unsigned int>(call->args->getInt()); }
                 } else if (ann->a[i]->isCall("restart_luby")) {
                     AST::Call* call = ann->a[i]->getCall("restart_luby");
-                    so.restart_type = LUBY;
-                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                    if (so.restart_type_override) { so.restart_type = LUBY; }
+                    if (so.restart_scale_override) { so.restart_scale = static_cast<unsigned int>(call->args->getInt()); }
                 } else if (ann->a[i]->isCall("restart_geometric")) {
                     AST::Call* call = ann->a[i]->getCall("restart_geometric");
-                    so.restart_type = GEOMETRIC;
+                    if (so.restart_type_override) { so.restart_type = GEOMETRIC; }
                     AST::Array* args = call->getArgs(2);
-                    so.restart_base = args->a[0]->getFloat();
+                    if (so.restart_base_override) { so.restart_base = args->a[0]->getFloat(); }
                     if (so.restart_base < 1.0) {
                         CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");
                     }
-                    so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt());
+                    if (so.restart_scale_override) { so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt()); }
                 } else if (ann->a[i]->isCall("seq_search")) {
                     // Get the call
                     AST::Call* c = ann->a[i]->getCall();

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -360,6 +360,9 @@ namespace FlatZinc {
                     so.restart_type = GEOMETRIC;
                     AST::Array* args = call->getArgs(2);
                     so.restart_base = args->a[0]->getFloat();
+                    if (so.restart_base < 1.0) {
+                        CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");
+                    }
                     so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt());
                 } else if (ann->a[i]->isCall("seq_search")) {
                     // Get the call

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -343,7 +343,25 @@ namespace FlatZinc {
     void FlatZincSpace::parseSolveAnn(AST::Array* ann, BranchGroup* branching, int & nbNonEmptySearchAnnotations) {
         if (ann) {
             for (unsigned int i = 0; i < ann->a.size(); i++) {
-                if (ann->a[i]->isCall("seq_search")) {
+                if (ann->a[i]->isCall("restart_constant")) {
+                    AST::Call* call = ann->a[i]->getCall("restart_constant");
+                    so.restart_type = CONSTANT;
+                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                } else if (ann->a[i]->isCall("restart_linear")) {
+                    AST::Call* call = ann->a[i]->getCall("restart_linear");
+                    so.restart_type = LINEAR;
+                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                } else if (ann->a[i]->isCall("restart_luby")) {
+                    AST::Call* call = ann->a[i]->getCall("restart_luby");
+                    so.restart_type = LUBY;
+                    so.restart_scale = static_cast<unsigned int>(call->args->getInt());
+                } else if (ann->a[i]->isCall("restart_geometric")) {
+                    AST::Call* call = ann->a[i]->getCall("restart_geometric");
+                    so.restart_type = GEOMETRIC;
+                    AST::Array* args = call->getArgs(2);
+                    so.restart_base = args->a[0]->getFloat();
+                    so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt());
+                } else if (ann->a[i]->isCall("seq_search")) {
                     // Get the call
                     AST::Call* c = ann->a[i]->getCall();
                     // Create a new branch group and add to the branching

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -343,7 +343,9 @@ namespace FlatZinc {
     void FlatZincSpace::parseSolveAnn(AST::Array* ann, BranchGroup* branching, int & nbNonEmptySearchAnnotations) {
         if (ann) {
             for (unsigned int i = 0; i < ann->a.size(); i++) {
-                if (ann->a[i]->isCall("restart_constant")) {
+                if (ann->a[i]->isCall("restart_none")) {
+                    so.restart_type = NONE;
+                } else if (ann->a[i]->isCall("restart_constant")) {
                     AST::Call* call = ann->a[i]->getCall("restart_constant");
                     so.restart_type = CONSTANT;
                     so.restart_scale = static_cast<unsigned int>(call->args->getInt());

--- a/chuffed/flatzinc/lexer.lxx
+++ b/chuffed/flatzinc/lexer.lxx
@@ -54,9 +54,9 @@ int yy_input_proc(char* buf, int size, yyscan_t yyscanner);
 -?[0-9]+          { yylval->iValue = atoi(yytext); return INT_LIT; }
 -?0x[0-9A-Fa-f]+  { yylval->iValue = atoi(yytext); return INT_LIT; }
 -?0o[0-7]+        { yylval->iValue = atoi(yytext); return INT_LIT; }
--?[0-9]+\.[0-9]+  { return FLOAT_LIT; }
--?[0-9]+\.[0-9]+[Ee][+-]?[0-9]+  { return FLOAT_LIT; }
--?[0-9]+[Ee][+-]?[0-9]+  { return FLOAT_LIT; }
+-?[0-9]+\.[0-9]+  { yylval->dValue = atof(yytext); return FLOAT_LIT; }
+-?[0-9]+\.[0-9]+[Ee][+-]?[0-9]+  { yylval->dValue = atof(yytext); return FLOAT_LIT; }
+-?[0-9]+[Ee][+-]?[0-9]+  { yylval->dValue = atof(yytext); return FLOAT_LIT; }
 [=:;{}(),\[\]\.]    { return *yytext; }
 \.\.              { return DOTDOT; }
 ::                { return COLONCOLON; }

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -17,7 +17,7 @@ predicate range_size_fzn(var int: x, var int: rs);
 
 
 %------------------------------------------------------------------------------%
-% Following search annotation is a place holders until it is includede in the
+% Following search annotation is a place holders until it is included in the
 % MiniZinc distribution
 
 /** @group annotations.search Specify search on a group of searches \a search,
@@ -45,4 +45,15 @@ annotation smallest_largest;
 /** @group annotations.search.varsel Choose the variable with the largest smallest value in its domain */
 annotation largest_smallest;
 
+%------------------------------------------------------------------------------%
+% Following restart strategy annotations are just place holders until they are
+% included in the MiniZinc distributions.
 
+/** @group annotations.search.restart Restart after fixed number of conflicts */
+annotation restart_constant(int: nodes);
+/** @group annotations.search.restart Restart with scaled Luby sequence */
+annotation restart_luby(int: scale);
+/** @group annotations.search.restart Restart with scaled geometric sequence (scale*base^n in the n-th iteration) */
+annotation restart_geometric(float: base, int: scale);
+/** @group annotations.search.restart Restart with linear sequence (scale*n in the n-th iteration) */
+annotation restart_linear(int: scale);

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -49,6 +49,8 @@ annotation largest_smallest;
 % Following restart strategy annotations are just place holders until they are
 % included in the MiniZinc distributions.
 
+/** @group annotations.search.restart Do not use restarts during search */
+annotation restart_none;
 /** @group annotations.search.restart Restart after fixed number of conflicts */
 annotation restart_constant(int: nodes);
 /** @group annotations.search.restart Restart with scaled Luby sequence */

--- a/chuffed/flatzinc/mznlib/redefinitions.mzn
+++ b/chuffed/flatzinc/mznlib/redefinitions.mzn
@@ -90,3 +90,13 @@ predicate int_ge_imp(var int: a, var int: b, var bool: r);
 predicate int_gt_imp(var int: a, var int: b, var bool: r);
 predicate int_le_imp(var int: a, var int: b, var bool: r);
 predicate int_lt_imp(var int: a, var int: b, var bool: r);
+
+%% Restart Strategies
+% restart after fixed number of nodes
+annotation restart_constant(int: nodes);
+% restart with scaled Luby sequence
+annotation restart_luby(int: scale);
+% restart with scaled geometric sequence (scale*base^n in the n-th iteration)
+annotation restart_geometric(float: base, int: scale);
+% restart with linear sequence (scale*n in the n-th iteration)
+annotation restart_linear(int: scale);

--- a/chuffed/flatzinc/mznlib/redefinitions.mzn
+++ b/chuffed/flatzinc/mznlib/redefinitions.mzn
@@ -91,12 +91,3 @@ predicate int_gt_imp(var int: a, var int: b, var bool: r);
 predicate int_le_imp(var int: a, var int: b, var bool: r);
 predicate int_lt_imp(var int: a, var int: b, var bool: r);
 
-%% Restart Strategies
-% restart after fixed number of nodes
-annotation restart_constant(int: nodes);
-% restart with scaled Luby sequence
-annotation restart_luby(int: scale);
-% restart with scaled geometric sequence (scale*base^n in the n-th iteration)
-annotation restart_geometric(float: base, int: scale);
-% restart with linear sequence (scale*n in the n-th iteration)
-annotation restart_linear(int: scale);


### PR DESCRIPTION
Currently Chuffed has it's own function to determine the number of conflicts that is very similar to Luby. This PR adds various other common cutoffs:
- Constant
- Linear
- Luby
- Geometric

These new strategies are accessible from command line and as FlatZinc annotation conform to the annotation and flags used by Gecode.
*Note that this changes the `--restart-base` flag to `--restart-scale`*.
The following annotations are added to the Chuffed MiniZinc library:
```
% restart after fixed number of nodes
annotation restart_constant(int: nodes);
% restart with scaled Luby sequence
annotation restart_luby(int: scale);
% restart with scaled geometric sequence (scale*base^n in the n-th iteration)
annotation restart_geometric(float: base, int: scale);
% restart with linear sequence (scale*n in the n-th iteration)
annotation restart_linear(int: scale);
```

I've taken care that except for the command line flag current (default) behaviour has not changed.