### PR TITLE
Add the usage of IntVarSL in fzn-chuffed

### DIFF
--- a/chuffed/core/stats.cpp
+++ b/chuffed/core/stats.cpp
@@ -43,19 +43,20 @@ void Engine::printStats() {
 	printf("%%%%%%mzn-stat: randomSeed=%d\n", so.rnd_seed);
 
 	if (so.verbosity >= 2) {
-		int nl = 0, el = 0, ll = 0;
+		int nl = 0, el = 0, ll = 0, sl = 0;
 		for (int i = 0; i < vars.size(); i++) {
 			switch (vars[i]->getType()) {
 				case INT_VAR: nl++; break;
 				case INT_VAR_EL: el++; break;
 				case INT_VAR_LL: ll++; break;
-				case INT_VAR_SL: el++; break;
+				case INT_VAR_SL: sl++; break;
 				default: NEVER;
 			}
 		}
 		printf("%%%%%%mzn-stat: noLitIntVars=%d\n", nl);
 		printf("%%%%%%mzn-stat: eagerLitIntVars=%d\n", el);
 		printf("%%%%%%mzn-stat: lazyLitIntVars=%d\n", ll);
+		printf("%%%%%%mzn-stat: sparseLitIntVars=%d\n", sl);
 		printf("%%%%%%mzn-stat: solutions=%lld\n", solutions);
 
 		if (so.ldsb) {

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -105,7 +105,12 @@ namespace FlatZinc {
                     for (unsigned int i = 0; i < sl->s.size(); i++) d.push(sl->s[i]);
                     sort((int*) d, (int*) d + d.size());
                     v = ::newIntVar(d[0], d.last());
-                    if (!v->allowSet(d)) TL_FAIL();
+                    if ((d.last()-d[0] >= d.size() * mylog2(d.size())) ||
+                        (d.size() <= so.eager_limit && (d.last() - d[0] + 1) > so.eager_limit)) {
+                        new (v) IntVarSL(*v, d);
+                    } else {
+                        if (!v->allowSet(d)) TL_FAIL();
+                    }
                 }
             } 
             else {


### PR DESCRIPTION
Sparse Literal variables should be used in cases where the number of
values in the domain is sparse. This commit enables two cases:
- When the domain is bigger than the eager limit, but contains less
values than the eager limit.
- When the heuristic from specializeSL is reached