### PR TITLE
Fix GCC6+ segmentation fault in the FlatZinc parser

### DIFF
--- a/chuffed/flatzinc/parser.yxx
+++ b/chuffed/flatzinc/parser.yxx
@@ -727,7 +727,7 @@ vardecl_item :
             ParserState* pp = static_cast<ParserState*>(parm);
             yyassert(pp, $3 == 1, "Arrays must start at 1");
             if (!pp->hadError) {
-                bool print = $12->hasCall("output_array");
+                bool print = $12 && $12->hasCall("output_array");
                 vector<int> vars($5);
                 yyassert(pp, !$9() || !$9.some()->empty(), "Empty var int domain.");
                 if (!pp->hadError) {
@@ -782,7 +782,7 @@ vardecl_item :
                 ID annotations vardecl_bool_var_array_init
         {
             ParserState* pp = static_cast<ParserState*>(parm);
-            bool print = $12->hasCall("output_array");
+            bool print = $12 && $12->hasCall("output_array");
             yyassert(pp, $3 == 1, "Arrays must start at 1");
             if (!pp->hadError) {
                 vector<int> vars($5);
@@ -841,7 +841,7 @@ vardecl_item :
                 ID annotations vardecl_set_var_array_init
         { 
             ParserState* pp = static_cast<ParserState*>(parm);
-            bool print = $14->hasCall("output_array");
+            bool print = $14 && $14->hasCall("output_array");
             yyassert(pp, $3 == 1, "Arrays must start at 1");
             if (!pp->hadError) {
                 vector<int> vars($5);


### PR DESCRIPTION
This PR introduces a small fix for the FlatZinc parser which solves #37. The fix adds an extra check to the usages of the "hasCall" method to make sure the object on which it is called actually exist.