### PR TITLE
Hide full error path when building in release

### DIFF
--- a/chuffed/support/misc.h
+++ b/chuffed/support/misc.h
@@ -9,9 +9,11 @@
 
 #ifdef WIN32
 #include <windows.h>
+#define __SEP__ '\\'
 #else
 #include <sys/time.h>
 #include <unistd.h>
+#define __SEP__ '/'
 #endif
 
 #include <stdint.h>
@@ -25,9 +27,13 @@ extern uint64_t bit[65];
 #define getbit(i,s) (((s) >> (i)) & 1)
 
 //------
-
+#ifdef NDEBUG
+#define __FILENAME__ (strrchr(__FILE__, __SEP__) ? strrchr(__FILE__, __SEP__) + 1 : __FILE__)
+#else
+#define __FILENAME__ __FILE__
+#endif
 #define CHUFFED_ERROR(...) do {                                                            \
-	fprintf(stderr, "%s:%d: ", __FILE__, __LINE__);         \
+	fprintf(stderr, "%s:%d: ", __FILENAME__, __LINE__);         \
 	fprintf(stderr, __VA_ARGS__);                                                    \
 	abort();                                                                         \
 } while (0)


### PR DESCRIPTION
This is a simple change that hide the absolute path when compiling in release mode. This means that, for example, when `fzn-chuffed` is shipped in MiniZinc, the error will be:
```
arithmetic.cpp:605: Cannot handle non-sign-fixed vars
```
instead of
```
/Users/jdek0001/Playground/runner/builds/373b1426/0/minizinc/vendor/chuffed/chuffed/primitives/arithmetic.cpp:605: Cannot handle non-sign-fixed vars
```