### PR TITLE
Remove the unimplemented bool_sum_ne from mznlib and registry

### DIFF
--- a/chuffed/flatzinc/mznlib/fzn_count_neq.mzn
+++ b/chuffed/flatzinc/mznlib/fzn_count_neq.mzn
@@ -1,2 +1,0 @@
-predicate fzn_count_neq(array[int] of var int: x, var int: y, var int: c) =
-    bool_sum_ne([x[i] == y | i in index_set(x)], c);

--- a/chuffed/flatzinc/mznlib/fzn_count_neq_par.mzn
+++ b/chuffed/flatzinc/mznlib/fzn_count_neq_par.mzn
@@ -1,2 +1,0 @@
-predicate fzn_count_neq_par(array[int] of var int: x, int: y, int: c) =
-    bool_sum_ne([x[i] == y | i in index_set(x)], c);

--- a/chuffed/flatzinc/registry.cpp
+++ b/chuffed/flatzinc/registry.cpp
@@ -800,9 +800,6 @@ namespace FlatZinc {
 		void p_bool_sum_eq(const ConExpr& ce, AST::Node* ann) {
 			p_bool_sum_CMP(IRT_EQ, ce, ann);
 		}
-		void p_bool_sum_ne(const ConExpr& ce, AST::Node* ann) {
-			p_bool_sum_CMP(IRT_NE, ce, ann);
-		}
 		void p_bool_sum_le(const ConExpr& ce, AST::Node* ann) {
 			p_bool_sum_CMP(IRT_LE, ce, ann);
 		}
@@ -1139,7 +1136,6 @@ namespace FlatZinc {
 				registry().add("cumulatives", &p_cumulatives);
 */
 				registry().add("bool_sum_eq", &p_bool_sum_eq);
-				registry().add("bool_sum_ne", &p_bool_sum_ne);
 				registry().add("bool_sum_le", &p_bool_sum_le);
 				registry().add("bool_sum_lt", &p_bool_sum_lt);
 				registry().add("bool_sum_ge", &p_bool_sum_ge);


### PR DESCRIPTION
The new MiniZinc library added the usage of a `bool_sum_ne`, but there is no internal implementation. The `bool_linear` function used for Boolean linear comparisons for all the other summations does not have a case for `IRT_NE` resulting in an error when `bool_sum_ne` is used in the FlatZinc.

This PR just removes the usage of `bool_sum_ne` relying on the redefinition (as was the case before the changes)