### PR TITLE
Grow FlatZinc variable vector even if size is 0

### DIFF
--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -83,7 +83,7 @@ namespace FlatZinc {
     void FlatZincSpace::newIntVar(IntVarSpec* vs) {
         // Resizing of the vectors if required
         if (intVarCount == iv.size()) {
-            const int newSize = 2 * intVarCount;
+            const int newSize = intVarCount > 0 ? 2 * intVarCount : 1;
             iv.growTo(newSize);
             iv_introduced.resize(newSize);
         }
@@ -129,7 +129,7 @@ namespace FlatZinc {
     void FlatZincSpace::newBoolVar(BoolVarSpec* vs) {
         // Resizing of the vectors if required
         if (boolVarCount == iv.size()) {
-            const int newSize = 2 * boolVarCount;
+            const int newSize = boolVarCount > 0 ? 2 * boolVarCount : 1;
             bv.growTo(newSize);
             bv_introduced.resize(newSize);
         }


### PR DESCRIPTION
Ensures that even if the var count is initially zero, it can still be grown as required.

This prevents a crash for flatzinc like
```
solve minimize 1;
```
