### PR TITLE
Fix cpprofiler integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # ------------- CP Profiler Integration -------------
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration")
+if(EXISTS "${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration/connector.hpp")
   set(CHUFFED_PROFILER_SOURCES
     ${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration/connector.hpp
     ${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration/message.hpp
@@ -151,7 +151,7 @@ add_library(chuffed
   ${CHUFFED_PROFILER_SOURCES}
 )
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration")
+if(CHUFFED_PROFILER_SOURCES)
   target_compile_definitions(chuffed PRIVATE HAS_PROFILER)
 endif()
 

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -102,8 +102,8 @@ Options::Options() :
 
 	, alldiff_cheat(true)
 	, alldiff_stage(true)
-  , cpprofiler_enabled(false)
 #ifdef HAS_PROFILER
+  , cpprofiler_enabled(false)
   , cpprofiler_id(-1)
   , cpprofiler_port(6565)
 #endif


### PR DESCRIPTION
Fixes compilation of chuffed when the profiler submodule is not present, and also fixes cleanup of the profiler where for some reason `std::cout` gets broken if you disconnect when not actually connected on Unix.