### PR TITLE
Do not trigger flex unless Bison is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ else()
 endif()
 
 find_package(FLEX)
-if(FLEX_FOUND)
+if(FLEX_FOUND AND BISON_FOUND)
   flex_target(FZNLexer
     ${PROJECT_SOURCE_DIR}/chuffed/flatzinc/lexer.lxx
     ${PROJECT_BINARY_DIR}/lexer.yy.cpp


### PR DESCRIPTION
Because of the Flex dependency on the Bison target, we should only trigger the Flex target if a compatible version of Bison is found.