### PR TITLE
Rename -cpprofiler flag to --cp-profiler, update submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cp-profiler-integration"]
 	path = submodules/cp-profiler-integration
-	url = https://github.com/cp-profiler/cpp-integration
+	url = https://gitlab.com/minizinc/cp-profiler-integration.git

--- a/chuffed.msc.in
+++ b/chuffed.msc.in
@@ -6,7 +6,7 @@
   "mznlib": "../chuffed",
   "executable": "${REL_INSTALL_BINARY}",
   "tags": ["cp","lcg","int"],
-  "stdFlags": ["-a","-f","-n","-r","-s","-v","-cpprofiler"],
+  "stdFlags": ["-a","-f","-n","-r","-s","-v","--cp-profiler"],
   "extraFlags": [
       ["--prop-fifo", "Use FIFO queues for propagation", "bool", "false"],
       ["--vsids", "Use activity-based search on the Boolean variables", "bool", "false"],

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -609,14 +609,14 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
     } else if (cop.get("-s -S")) {
       so.verbosity = 1;
 #ifdef HAS_PROFILER
-    } else if (cop.get("-cpprofiler", &stringBuffer)) {
+    } else if (cop.get("--cp-profiler", &stringBuffer)) {
       std::stringstream ss(stringBuffer);
       char sep;
       ss >> so.cpprofiler_id >> sep >> so.cpprofiler_port;
       if (sep == ',' && ss.eof()) {
         so.cpprofiler_enabled = true;
       } else {
-        CHUFFED_ERROR("Invalid value for -cpprofiler.");
+        CHUFFED_ERROR("Invalid value for --cp-profiler.");
       }
 #endif
     } else if (argv[i][0] == '-') {


### PR DESCRIPTION
Renames the `-cpprofiler` flag to `--cp-profiler` to be consistent with normal flag naming. This enables support for search profiling in the upcoming release of the MiniZinc IDE.

The CP-Profiler integration will now be maintained at https://gitlab.com/minizinc/cp-profiler-integration.

TODO: We should look into the possibility of using CMake to fetch the profiler integration submodule rather than requiring users to do it when building.