### PR TITLE
Fix inclusion path error

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,41 @@
+name: CMake
+
+on: [push,pull_request]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX="${{runner.workspace}}/install"
+
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target install
+
+    # TODO: Run Chuffed tests
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}
+        path: ${{runner.workspace}}/install/

--- a/chuffed/globals/EdExplFinder.h
+++ b/chuffed/globals/EdExplFinder.h
@@ -7,8 +7,8 @@
 
 #include <vector>
 #include <queue>
-#include <support/vec.h>
-#include <core/propagator.h>
+#include <chuffed/core/propagator.h>
+#include <chuffed/support/vec.h>
 
 /**
  * Class that will help to find variable inequalities used to explain propagation of lcs bounds


### PR DESCRIPTION
This PR fixes the inclusion error introduced in #68, which prevents the building of Chuffed.

To prevent this from happening in the future, this PR also adds a GitHub action that builds Chuffed when new commits are pushed to the repository. This should allow us to see if a PR code base builds before merging back into the main repository.