### PR TITLE
Add impact metric

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 # ---------- Support for impact branching -----------
 
-if(SUPPORT_VAR_BRANCH_IMPACT)
+if(SUPPORT_VAR_IMPACT)
   add_definitions(-DHAS_VAR_IMPACT)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,12 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/submodules/cp-profiler-integration/protobuf")
 
 endif()
 
+# ---------- Support for impact branching -----------
+
+if(SUPPORT_VAR_BRANCH_IMPACT)
+  add_definitions(-DVAR_BRANCH_IMPACT=1)
+endif()
+
 # ------------- Main Chuffed Definition -------------
 
 add_library(chuffed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 # ---------- Support for impact branching -----------
 
 if(SUPPORT_VAR_BRANCH_IMPACT)
-  add_definitions(-DVAR_BRANCH_IMPACT=1)
+  add_definitions(-DHAS_VAR_IMPACT)
 endif()
 
 # ------------- Main Chuffed Definition -------------
@@ -157,6 +157,7 @@ add_library(chuffed
   chuffed/primitives/domain.cpp
   chuffed/primitives/binary.cpp
   chuffed/branching/branching.cpp
+  chuffed/branching/impact.cpp
   chuffed/core/init.cpp
   chuffed/core/stats.cpp
   chuffed/core/engine.cpp

--- a/chuffed/branching/branching.h
+++ b/chuffed/branching/branching.h
@@ -26,7 +26,7 @@ enum VarBranch {
 	VAR_PSEUDO_COST,         // largest pseudo cost from MIP
 	VAR_ACTIVITY,            // largest vsids activity
 	VAR_RANDOM,              // random
-#if VAR_BRANCH_IMPACT
+#ifdef HAS_VAR_IMPACT
 	VAR_IMPACT,              // best filtering results so far
 #endif
 };

--- a/chuffed/branching/branching.h
+++ b/chuffed/branching/branching.h
@@ -25,7 +25,10 @@ enum VarBranch {
 	VAR_REDUCED_COST,        // largest reduced cost from MIP
 	VAR_PSEUDO_COST,         // largest pseudo cost from MIP
 	VAR_ACTIVITY,            // largest vsids activity
-	VAR_RANDOM               // random
+	VAR_RANDOM,              // random
+#if VAR_BRANCH_IMPACT
+	VAR_IMPACT,              // best filtering results so far
+#endif
 };
 
 //-----

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -7,8 +7,6 @@ constexpr double CLEARED_LOCAL = 0.42;
 constexpr double CLEARED_GLOBAL = 0.42;
 constexpr double CLEARED_REPARTITION = 0.42;
 
-#include <iostream>
-
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 	int const n = newSizes.size();
 	if (!n || previousSizes.size() != n) NEVER;

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -1,11 +1,11 @@
 #include <chuffed/branching/impact.h>
 
 constexpr double WEIGHT_LOCAL = 420;
-constexpr double WEIGHT_GLOBAL = 420;
-constexpr double WEIGHT_REPARTITION =  42;
+constexpr double WEIGHT_GLOBAL = 42;
+constexpr double WEIGHT_REPARTITION = 420;
 constexpr double CLEARED_LOCAL = 0.42;
-constexpr double CLEARED_GLOBAL = 0.42;
-constexpr double CLEARED_REPARTITION = 1.00;
+constexpr double CLEARED_GLOBAL = 0.042;
+constexpr double CLEARED_REPARTITION = 1.00;;
 
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 	int const n = newSizes.size();

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -7,6 +7,8 @@ constexpr double CLEARED_LOCAL = 0.42;
 constexpr double CLEARED_GLOBAL = 0.42;
 constexpr double CLEARED_REPARTITION = 0.42;
 
+#include <iostream>
+
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 	int const n = newSizes.size();
 	if (!n || previousSizes.size() != n) NEVER;

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -1,11 +1,11 @@
 #include <chuffed/branching/impact.h>
 
-constexpr double WEIGHT_LOCAL =  42;
-constexpr double WEIGHT_GLOBAL =  42;
+constexpr double WEIGHT_LOCAL = 420;
+constexpr double WEIGHT_GLOBAL = 420;
 constexpr double WEIGHT_REPARTITION =  42;
 constexpr double CLEARED_LOCAL = 0.42;
 constexpr double CLEARED_GLOBAL = 0.42;
-constexpr double CLEARED_REPARTITION = 0.42;
+constexpr double CLEARED_REPARTITION = 1.00;
 
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 	int const n = newSizes.size();
@@ -25,6 +25,37 @@ double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 			repartition += CLEARED_REPARTITION;
 		} else {
 			int const fi = ti - newSizes[i];
+			if (fi) {			
+				local += fi / ti;
+				global += fi;
+				++repartition;
+			}
+		}
+	}
+	return (  WEIGHT_LOCAL * local / n
+			+ WEIGHT_GLOBAL * global / total
+			+ WEIGHT_REPARTITION * repartition / n
+		) / (WEIGHT_LOCAL + WEIGHT_GLOBAL + WEIGHT_REPARTITION);
+}
+
+double solvedImpact(vec<int> const &previousSizes) {
+	int const n = previousSizes.size();
+	if (!n) NEVER;
+
+	double local = 0;
+	double global = 0;
+	int total = 0;
+	double repartition = 0;
+
+	for (int i = 0; i < n; ++i) {
+		int const ti = previousSizes[i];
+		total += ti;
+		if (previousSizes[i] == 1) {
+			local += CLEARED_LOCAL;
+			global += CLEARED_GLOBAL;
+			repartition += CLEARED_REPARTITION;
+		} else {
+			int const fi = ti - 1;
 			if (fi) {			
 				local += fi / ti;
 				global += fi;

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -1,0 +1,39 @@
+#include <chuffed/branching/impact.h>
+
+constexpr double WEIGHT_LOCAL =  42;
+constexpr double WEIGHT_GLOBAL =  42;
+constexpr double WEIGHT_REPARTITION =  42;
+constexpr double CLEARED_LOCAL = 0.42;
+constexpr double CLEARED_GLOBAL = 0.42;
+constexpr double CLEARED_REPARTITION = 0.42;
+
+double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
+	int const n = newSizes.size();
+	if (!n || previousSizes.size() != n) NEVER;
+
+	double local = 0;
+	double global = 0;
+	int total = 0;
+	double repartition = 0;
+
+	for (int i = 0; i < n; ++i) {
+		int const ti = previousSizes[i];
+		total += ti;
+		if (previousSizes[i] == 1) {
+			local += CLEARED_LOCAL;
+			global += CLEARED_GLOBAL;
+			repartition += CLEARED_REPARTITION;
+		} else {
+			int const fi = ti - newSizes[i];
+			if (fi) {			
+				local += fi / ti;
+				global += fi;
+				++repartition;
+			}
+		}
+	}
+	return (  WEIGHT_LOCAL * local / n
+			+ WEIGHT_GLOBAL * global / total
+			+ WEIGHT_REPARTITION * repartition / n
+		) / (WEIGHT_LOCAL + WEIGHT_GLOBAL + WEIGHT_REPARTITION);
+}

--- a/chuffed/branching/impact.cpp
+++ b/chuffed/branching/impact.cpp
@@ -5,7 +5,7 @@ constexpr double WEIGHT_GLOBAL = 42;
 constexpr double WEIGHT_REPARTITION = 420;
 constexpr double CLEARED_LOCAL = 0.42;
 constexpr double CLEARED_GLOBAL = 0.042;
-constexpr double CLEARED_REPARTITION = 1.00;;
+constexpr double CLEARED_REPARTITION = 1.00;
 
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes) {
 	int const n = newSizes.size();

--- a/chuffed/branching/impact.h
+++ b/chuffed/branching/impact.h
@@ -4,6 +4,7 @@
 #include <chuffed/support/misc.h>
 
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes);
+double solvedImpact(vec<int> const &previousSizes);
 
 #endif
 #endif

--- a/chuffed/branching/impact.h
+++ b/chuffed/branching/impact.h
@@ -1,0 +1,8 @@
+#ifndef impact_h
+#define impact_h
+
+#include <chuffed/support/misc.h>
+
+double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes);
+
+#endif

--- a/chuffed/branching/impact.h
+++ b/chuffed/branching/impact.h
@@ -1,8 +1,9 @@
 #ifndef impact_h
 #define impact_h
-
+#ifdef HAS_VAR_IMPACT
 #include <chuffed/support/misc.h>
 
 double processImpact(vec<int> const &previousSizes, vec<int> const &newSizes);
 
+#endif
 #endif

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -842,6 +842,10 @@ RESULT Engine::search(const std::string& problemLabel) {
                 //}
 #endif
                                     
+#ifdef HAS_VAR_IMPACT
+				if (last_int) last_int->updateImpact(solvedImpact(var_sizes));
+#endif
+
                 mostRecentLabel = "";
                 if (!opt_var) {
                     if (solutions == so.nof_solutions) return RES_SAT;

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -12,6 +12,7 @@
 #include <chuffed/core/sat.h>
 #include <chuffed/core/propagator.h>
 #include <chuffed/branching/branching.h>
+#include <chuffed/branching/impact.h>
 #include <chuffed/mip/mip.h>
 #include <chuffed/parallel/parallel.h>
 #include <chuffed/ldsb/ldsb.h>
@@ -206,6 +207,9 @@ Engine::Engine()
     , solutions(0)
     , next_simp_db(0)
     , output_stream(&std::cout)
+#ifdef HAS_VAR_IMPACT
+	, last_int(nullptr)
+#endif
 {
     p_queue.growTo(num_queues);
     for (int i = 0; i < 64; i++) bit[i] = ((long long) 1 << i);
@@ -240,6 +244,11 @@ inline void Engine::doFixPointStuff() {
 inline void Engine::makeDecision(DecInfo& di, int alt) {
     ++nodes;
     altpath.push_back(alt);
+#ifdef HAS_VAR_IMPACT
+	vec<int> sizes(0);
+	if (last_int)
+		last_int->updateImpact(processImpact(var_sizes, getVarSizes(sizes)));
+#endif
     if (di.var) {
 #if DEBUG_VERBOSE
         std::cerr << "makeDecision: " << intVarString[(IntVar*)di.var] << " / " << di.val << " (" << alt << ")" << std::endl;
@@ -259,6 +268,13 @@ inline void Engine::makeDecision(DecInfo& di, int alt) {
             mostRecentLabel = ss.str();
         }
 #endif
+#ifdef HAS_VAR_IMPACT
+		last_int = (IntVar*) di.var;
+		if (sizes.size())
+			sizes.moveTo(var_sizes);
+		else
+			getVarSizes(var_sizes);
+#endif
         ((IntVar*) di.var)->set(di.val, di.type ^ alt);
     } else {
 #if DEBUG_VERBOSE
@@ -270,6 +286,9 @@ inline void Engine::makeDecision(DecInfo& di, int alt) {
             ss << getLitString(di.val^alt);
             mostRecentLabel = ss.str();
         }
+#endif
+#ifdef HAS_VAR_IMPACT
+		last_int = nullptr;
 #endif
         sat.enqueue(toLit(di.val ^ alt));
     }
@@ -388,6 +407,9 @@ void Engine::btToLevel(int level) {
         std::cerr << "trail_lim is now: " << showVec(trail_lim) << "\n";
     }
     dec_info.resize(level);
+#ifdef HAS_VAR_IMPACT
+	last_int = nullptr;
+#endif
 }
 
 
@@ -483,6 +505,18 @@ void Engine::toggleVSIDS() {
         so.vsids = false;
     }
 }
+
+#ifdef HAS_VAR_IMPACT
+vec<int> &Engine::getVarSizes(vec<int> &outVarSizes) const {
+	int const n = vars.size();
+	outVarSizes.growTo(n); // hopefully optimised by compiler
+	for (int i = 0; i < n; ++i) {
+		outVarSizes[i] = vars[i]->size();
+	}
+	return outVarSizes;
+}
+#endif
+
 
 RESULT Engine::search(const std::string& problemLabel) {
     unsigned int starts = 1;
@@ -850,6 +884,12 @@ RESULT Engine::search(const std::string& problemLabel) {
             }
 #endif
           
+#ifdef HAD_VAR_IMPACT
+			if (di->var) {
+				std::cerr << "Deciding on: ";
+				((IntVar*)di->var)->print();
+			}
+#endif
             makeDecision(*di, 0);
 
             delete di;

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -888,12 +888,6 @@ RESULT Engine::search(const std::string& problemLabel) {
             }
 #endif
           
-#ifdef HAD_VAR_IMPACT
-			if (di->var) {
-				std::cerr << "Deciding on: ";
-				((IntVar*)di->var)->print();
-			}
-#endif
             makeDecision(*di, 0);
 
             delete di;

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -31,7 +31,7 @@ public:
     // Problem setup
     vec<IntVar*> vars;              // List of int vars
 #ifdef HAS_VAR_IMPACT
-	vec<int> varsizes;              // List of int vars sizes
+	vec<int> var_sizes;              // List of int vars sizes
 #endif
     vec<Branching*> outputs;        // List of output vars
     vec<Propagator*> propagators;   // List of propagators
@@ -48,6 +48,9 @@ public:
     int best_sol;
     RESULT status;
     time_point time_out;
+#ifdef HAS_VAR_IMPACT
+	IntVar *last_int; // Int vat last branched on - for impact calculation
+#endif
 
     // Intermediate propagation state
     vec<IntVar*> v_queue;           // List of changed vars
@@ -89,6 +92,9 @@ private:
     void blockCurrentSol();
     unsigned int getRestartLimit(unsigned int i); // Return the restart limit for restart i
     void toggleVSIDS();
+#if HAS_VAR_IMPACT
+	vec<int> &getVarSizes(vec<int> &outVarSizes) const;
+#endif
 
 public:
 

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -30,6 +30,9 @@ public:
 
     // Problem setup
     vec<IntVar*> vars;              // List of int vars
+#ifdef HAS_VAR_IMPACT
+	vec<int> varsizes;              // List of int vars sizes
+#endif
     vec<Branching*> outputs;        // List of output vars
     vec<Propagator*> propagators;   // List of propagators
     vec<PseudoProp*> pseudo_props;  // List of pseudo propagators

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -49,7 +49,7 @@ public:
     RESULT status;
     time_point time_out;
 #ifdef HAS_VAR_IMPACT
-	IntVar *last_int; // Int vat last branched on - for impact calculation
+	IntVar *last_int; // Int var last branched on - for impact calculation
 #endif
 
     // Intermediate propagation state

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -47,7 +47,7 @@ namespace FlatZinc {
             if (s->id == "most_constrained") return VAR_SIZE_MIN;
             if (s->id == "max_regret") return VAR_REGRET_MIN_MAX;
             if (s->id == "random_order") return VAR_RANDOM;
-#if VAR_BRANCH_IMPACT
+#ifdef HAS_VAR_IMPACT
             if (s->id == "impact") return VAR_IMPACT;
 #endif
         }

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -47,6 +47,9 @@ namespace FlatZinc {
             if (s->id == "most_constrained") return VAR_SIZE_MIN;
             if (s->id == "max_regret") return VAR_REGRET_MIN_MAX;
             if (s->id == "random_order") return VAR_RANDOM;
+#if VAR_BRANCH_IMPACT
+            if (s->id == "impact") return VAR_IMPACT;
+#endif
         }
         cerr << "% Warning: Unknown or not support variable selection annotation '";
         ann->print(cerr);

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -30,7 +30,7 @@ IntVar::IntVar(int _min, int _max) :
   , preferred_val(PV_MIN)
   , activity(0)
   , in_queue(false)
-  , impact(0.42)
+  , impact(0.042)
   , impact_count(0)
 {
 	assert(min_limit <= min && min <= max && max <= max_limit);

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -179,6 +179,10 @@ double IntVar::getScore(VarBranch vb) {
 		case VAR_REDUCED_COST  : return mip->getRC(this);
 		case VAR_ACTIVITY      : return activity;
                 case VAR_REGRET_MIN_MAX: return isFixed() ? 0 : (vals ? *++begin() - *begin() : 1);
+#if VAR_BRANCH_IMPACT
+		case VAR_IMPACT        : NOT_SUPPORTED; // return isFixed() ? 0 : 0.42;
+#endif
+
 		default: NOT_SUPPORTED;
 	}
 }

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -194,7 +194,6 @@ DecInfo* IntVar::branch() {
 //	for (int i = min; i <= max; i++) if (indomain(i)) possible.push(i);
 //	return new DecInfo(this, possible[rand()%possible.size()], 1);
 
-
 	switch (preferred_val) {
 		case PV_MIN       : return new DecInfo(this, min, 1);
 		case PV_MAX       : return new DecInfo(this, max, 1);

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -30,6 +30,8 @@ IntVar::IntVar(int _min, int _max) :
   , preferred_val(PV_MIN)
   , activity(0)
   , in_queue(false)
+  , impact(0.42)
+  , impact_count(0)
 {
 	assert(min_limit <= min && min <= max && max <= max_limit);
 	engine.vars.push(this);
@@ -179,8 +181,8 @@ double IntVar::getScore(VarBranch vb) {
 		case VAR_REDUCED_COST  : return mip->getRC(this);
 		case VAR_ACTIVITY      : return activity;
                 case VAR_REGRET_MIN_MAX: return isFixed() ? 0 : (vals ? *++begin() - *begin() : 1);
-#if VAR_BRANCH_IMPACT
-		case VAR_IMPACT        : NOT_SUPPORTED; // return isFixed() ? 0 : 0.42;
+#ifdef HAS_VAR_IMPACT
+		case VAR_IMPACT        : return isFixed() ? 0 : impact;
 #endif
 
 		default: NOT_SUPPORTED;

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -22,8 +22,7 @@
 // turning this off selects compatibility routines that scan value-by-value.
 #define INT_DOMAIN_LIST 0
 
-#define IMPACT_DAMPING 58.00
-
+#define IMPACT_DAMPING  0.16
 /*
 
 IntVar descriptions

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -22,7 +22,7 @@
 // turning this off selects compatibility routines that scan value-by-value.
 #define INT_DOMAIN_LIST 0
 
-#define IMPACT_DAMPING  0.16
+#define IMPACT_DAMPING 58.00
 
 /*
 

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -264,7 +264,7 @@ public:
 
 	int size() const {
 #ifdef HAS_VAR_IMPACT
-		if (!vals) return max - min;
+		if (!vals) return max + 1 - min;
 #else
 		assert(vals);
 #endif

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -263,7 +263,11 @@ public:
 	reverse_iterator rend() const { return reverse_iterator(begin()); }
 
 	int size() const {
+#ifdef HAS_VAR_IMPACT
+		if (!vals) return max - min;
+#else
 		assert(vals);
+#endif
 #if INT_DOMAIN_LIST
 		return vals_count;
 #else

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -22,6 +22,8 @@
 // turning this off selects compatibility routines that scan value-by-value.
 #define INT_DOMAIN_LIST 0
 
+#define IMPACT_DAMPING  0.16
+
 /*
 
 IntVar descriptions
@@ -69,6 +71,10 @@ public:
 	PreferredVal preferred_val;
 
 	double activity;
+#ifdef HAS_VAR_IMPACT
+	double impact;
+	int impact_count;
+#endif
 
 	IntVar(int min, int max);
 
@@ -117,6 +123,12 @@ public:
 
 	bool finished() { return isFixed(); }
 	double getScore(VarBranch vb);
+#ifdef HAS_VAR_IMPACT
+	double updateImpact(double const newImpact) {
+		double const weight = (1 - IMPACT_DAMPING) * impact_count++;
+		return impact = (weight * impact + newImpact) / (weight + 1);
+	}
+#endif
 	void setPreferredVal(PreferredVal p) { preferred_val = p; }
 	DecInfo* branch();
 
@@ -352,6 +364,8 @@ inline void IntVar::printLit(int val, int type) {
 inline void IntVar::print() {
 	fprintf(stderr, "v%d: min = %d, max = %d\n", var_id, (int) min, (int) max);
 }
+
+#undef IMPACT_DAMPING
 
 
 #include <chuffed/vars/int-var-el.h>


### PR DESCRIPTION
- Recommend squash and merging.
- Implemented as a feature you can switch on and off with
cmake -DSUPPORT_VAR_IMPACT=1
 so no impact unless desired

- - - - - - - - 

I did this as a school project under Ph.D. Claude-Guy Quimper, at ULaval, Quebec, QC, Canada.
Please don't hold him responsible for any wrong done by this PR.

Whilst doubtful in practical value in real-world use case, the metric still shows pretty good results in some use cases from the minizinc benchmark collection (https://github.com/MiniZinc/minizinc-benchmarks). 

And more importantly, I believe it has a significant value for academic purpose.
I believe Chuffed is still used a lot as primary solver in introductory-level courses.

As things stand, impact variable selection is still a rare occurrence in the field, and as a student it can be hard to see how it can truly affect search, and to learn its various caveats / benefits.

This leads to a hole in knowledge, and more importantly in interest in this heuristic, where we could expect great things from future work.