### PR TITLE
Feature/SBPS value-selection heuristic

### DIFF
--- a/chuffed.msc.in
+++ b/chuffed.msc.in
@@ -43,6 +43,7 @@
       ["--ldsb", "Use lightweight dynamic symmetry breaking constraints '1UIP crippled'", "bool", "false"],
       ["--ldsbta", "Use lightweight dynamic symmetry breaking constraints '1UIP'", "bool", "false"],
       ["--ldsbad", "Use lightweight dynamic symmetry breaking constraints 'all decision clause'", "bool", "false"],
+	  ["--sbps", "Use Solution-based phase saving (SBPS) value selection heuristic", "bool", "false"],
   ],
   "supportsMzn": false,
   "supportsFzn": true,

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -303,6 +303,11 @@ inline bool Engine::constrain() {
     best_sol = opt_var->getVal();
     opt_time = std::chrono::duration_cast<duration>(chuffed_clock::now() - start_time) - init_time;
 
+    // Solution-based phase saving
+    if (so.sbps) {
+        saveCurrentSolution();
+    }
+
     sat.btToLevel(0);
     restart_count++;
     nodepath.resize(0);
@@ -334,6 +339,14 @@ inline bool Engine::constrain() {
 
     /* return (opt_type ? opt_var->setMin(best_sol+1) : opt_var->setMax(best_sol-1)); */
     return true;
+}
+
+// Solution-based phase saving
+void Engine::saveCurrentSolution() {
+    sat.saveCurrentPolarities();            // SAT vars
+    for (int i = 0; i < vars.size(); i++) { // Int vars
+        vars[i]->saveCurrentValue();
+    }
 }
 
 bool Engine::propagate() {

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -96,6 +96,9 @@ public:
     void btToPos(int pos);
     void btToLevel(int level);
 
+    // Solution-based phase saving
+    void saveCurrentSolution();
+
     // Interface methods
     RESULT search(const std::string& problemLabel = "chuffed");
     void solve(Problem *p, const std::string& problemLabel = "chuffed");

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -665,6 +665,18 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
   if (so.vsids) engine.branching->add(&sat);
   
   if (so.learnt_stats_nogood) so.learnt_stats = true;
+
+// Warn user if SBPS is not used with an activity-based search and restarts
+    if (so.sbps) {
+        if (!(so.vsids || so.toggle_vsids || so.switch_to_vsids_after < 1000000000)) {
+            std::cerr << "WARNING: SBPS value selection must be used with an activity-based search to optimize its "
+                         "efficiency." << std::endl;
+        }
+        if (so.restart_type == NONE || so.restart_scale == 0) {
+            std::cerr << "WARNING: SBPS value selection must be used with restarts to optimize its "
+                         "efficiency." << std::endl;
+        }
+    }
   
 #ifndef PARALLEL
   if (so.parallel) {

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -24,6 +24,7 @@ Options::Options() :
 	, branch_random(false)
 	, switch_to_vsids_after(1000000000)
 	, sat_polarity(0)
+	, sbps(false)
 
 	, prop_fifo(false)
 
@@ -306,6 +307,10 @@ void printLongHelp(int& argc, char**& argv, const std::string& fileExt) {
   "  --sat-polarity <n>\n"
   "     Selection of the polarity of Boolean variables\n"
   "     (0 = default, 1 = same, 2 = anti, 3 = random) (default " << def.sat_polarity << ").\n"
+  "  --sbps [on|off]\n"
+  "     Use Solution-based phase saving (SBPS) value selection for integer and SAT variables. When branching on a "
+  "     variable, it branches if possible on the value this variable had in the best solution so far. If not possible, "
+  "     value selection is the user-defined one. (default " << (def.sbps ? "on" : "off") << ").\n"
   "\n"
   "Learning Options:\n"
   "  --lazy [on|off], --no-lazy\n"
@@ -508,6 +513,8 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.switch_to_vsids_after = intBuffer;
     } else if (cop.get("--sat-polarity", &intBuffer)) {
       so.sat_polarity = intBuffer;
+    } else if (cop.getBool("--sbps", boolBuffer)) {
+        so.sbps = boolBuffer;
     } else if (cop.getBool("--prop-fifo", boolBuffer)) {
       so.prop_fifo = boolBuffer;
     } else if (cop.getBool("--disj-edge-find", boolBuffer)) {

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -35,6 +35,7 @@ public:
 	bool branch_random;              // Use randomization for tie-breaking
     int switch_to_vsids_after;       // Switch from search ann to vsids after a given number of conflicts
 	int sat_polarity;                // Polarity of bool var to choose (0 = default, 1 = same, 2 = anti, 3 = random)
+	bool sbps;                       // Use Solution-based phase saving
 
 	// Propagator options
 	bool prop_fifo;                  // Propagators are queued in FIFO, otherwise LIFO

--- a/chuffed/core/sat.h
+++ b/chuffed/core/sat.h
@@ -159,6 +159,18 @@ public:
 	double getScore(VarBranch vb) { NEVER; }
 	DecInfo* branch();
 
+    // Solution-based phase saving
+    void saveCurrentPolarities() {
+        for (int i = 0; i < assigns.size(); i++) {
+            if (assigns[i] == toInt(l_True)) {
+                polarity[i] = false; // False means to branch 'true' on this SAT variable
+            }
+            else if (assigns[i] == toInt(l_False)) {
+                polarity[i] = true; // True means to branch 'false' on this SAT variable
+            }
+        }
+    }
+
 	// Parallel methods
 
 	void convertToSClause(Clause& c);

--- a/chuffed/vars/int-var-ll.cpp
+++ b/chuffed/vars/int-var-ll.cpp
@@ -31,7 +31,20 @@ IntVarLL::IntVarLL(const IntVar& other) : IntVar(other), ld(2), li(0), hi(1) {
 }
 
 DecInfo* IntVarLL::branch() {
-	switch (preferred_val) {
+    // Solution-based phase saving
+    if (SBPSValueSelection) {
+        // Check if we can branch on last solution value
+        if (indomain(lastSolutionValue)) {      // Lazy variables don't allow to use == decisions
+            if (setMinNotR(lastSolutionValue)) {
+                return new DecInfo(this, lastSolutionValue - 1, 2);
+            }
+            else {
+                return new DecInfo(this, lastSolutionValue, 3);
+            }
+        }
+    }
+
+    switch (preferred_val) {
 		case PV_MIN: return new DecInfo(this, min, 3);
 		case PV_MAX: return new DecInfo(this, max-1, 2);
 		case PV_SPLIT_MIN: return new DecInfo(this, min+(max-min-1)/2, 3);

--- a/chuffed/vars/int-var-ll.cpp
+++ b/chuffed/vars/int-var-ll.cpp
@@ -32,14 +32,14 @@ IntVarLL::IntVarLL(const IntVar& other) : IntVar(other), ld(2), li(0), hi(1) {
 
 DecInfo* IntVarLL::branch() {
     // Solution-based phase saving
-    if (SBPSValueSelection) {
+    if (sbps_value_selection) {
         // Check if we can branch on last solution value
-        if (indomain(lastSolutionValue)) {      // Lazy variables don't allow to use == decisions
-            if (setMinNotR(lastSolutionValue)) {
-                return new DecInfo(this, lastSolutionValue - 1, 2);
+        if (indomain(last_solution_value)) {      // Lazy variables don't allow to use == decisions
+            if (setMinNotR(last_solution_value)) {
+                return new DecInfo(this, last_solution_value - 1, 2);
             }
             else {
-                return new DecInfo(this, lastSolutionValue, 3);
+                return new DecInfo(this, last_solution_value, 3);
             }
         }
     }

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -30,6 +30,8 @@ IntVar::IntVar(int _min, int _max) :
   , preferred_val(PV_MIN)
   , activity(0)
   , in_queue(false)
+    , SBPSValueSelection(false)
+    , lastSolutionValue(-1)
 {
 	assert(min_limit <= min && min <= max && max <= max_limit);
 	engine.vars.push(this);
@@ -188,6 +190,13 @@ DecInfo* IntVar::branch() {
 //	for (int i = min; i <= max; i++) if (indomain(i)) possible.push(i);
 //	return new DecInfo(this, possible[rand()%possible.size()], 1);
 
+    // Solution-based phase saving
+    if (SBPSValueSelection) {
+        // Check if we can branch on last solution value
+        if (indomain(lastSolutionValue)) {
+            return new DecInfo(this, lastSolutionValue, 1);
+        }
+    }
 
 	switch (preferred_val) {
 		case PV_MIN       : return new DecInfo(this, min, 1);

--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -16,7 +16,7 @@ map<int,IntVar*> ic_map;
 extern std::map<IntVar*, std::string> intVarString;
 
 IntVar::IntVar(int _min, int _max) :
-		var_id(engine.vars.size())
+        var_id(engine.vars.size())
 	, min(_min)
 	, max(_max)
 	, min0(_min)
@@ -30,8 +30,8 @@ IntVar::IntVar(int _min, int _max) :
   , preferred_val(PV_MIN)
   , activity(0)
   , in_queue(false)
-    , SBPSValueSelection(false)
-    , lastSolutionValue(-1)
+    , sbps_value_selection(false)
+    , last_solution_value(-1)
 {
 	assert(min_limit <= min && min <= max && max <= max_limit);
 	engine.vars.push(this);
@@ -191,10 +191,10 @@ DecInfo* IntVar::branch() {
 //	return new DecInfo(this, possible[rand()%possible.size()], 1);
 
     // Solution-based phase saving
-    if (SBPSValueSelection) {
+    if (sbps_value_selection) {
         // Check if we can branch on last solution value
-        if (indomain(lastSolutionValue)) {
-            return new DecInfo(this, lastSolutionValue, 1);
+        if (indomain(last_solution_value)) {
+            return new DecInfo(this, last_solution_value, 1);
         }
     }
 

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -121,11 +121,11 @@ public:
 	DecInfo* branch();
 
     // Solution-based phase saving
-    bool SBPSValueSelection;
-    int lastSolutionValue;
+    bool sbps_value_selection;
+    int last_solution_value;
     void saveCurrentValue() {
-        lastSolutionValue = getVal();
-        if (!SBPSValueSelection) SBPSValueSelection = true;
+        last_solution_value = getVal();
+        if (!sbps_value_selection) sbps_value_selection = true;
     }
 
 //--------------------------------------------------

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -120,6 +120,14 @@ public:
 	void setPreferredVal(PreferredVal p) { preferred_val = p; }
 	DecInfo* branch();
 
+    // Solution-based phase saving
+    bool SBPSValueSelection;
+    int lastSolutionValue;
+    void saveCurrentValue() {
+        lastSolutionValue = getVal();
+        if (!SBPSValueSelection) SBPSValueSelection = true;
+    }
+
 //--------------------------------------------------
 // Type specialisation
 


### PR DESCRIPTION
This PR implements a new search option in Chuffed for optimization problems:

`--sbps on` tells the solver to use _Solution-based phase saving_ (SBPS) value selection heuristic for all variables (eager integers, lazy integers, SAT/boolean).

SBPS is based on the following paper:

> E. Demirović, G. Chu, and P. J. Stuckey. Solution-Based Phase Saving for CP: A Value-Selection Heuristic to Simulate Local Search Behavior in Complete Solvers. In *Principles and Practice of Constraint Programming*, Cham, 2018, p. 99‑108.

SBPS, used with restarts and an activity-based variable selection (VSIDS), simulates an automatic *Large Neighborhood Search* in the solver.  When branching on a variable, it branches if possible on the value this variable had in the best solution so far. If it is not possible, the value selection heuristic used is the user-defined one. In the context of a RCPSP I've worked on with an industrial partner, under the supervision of Claude-Guy Quimper, usage of this heuristic led to significant improvements, finding better solutions faster. This implementation is based on the original code of the related paper (we greatly thank Emir Demirović for that!), which have been updated for compatibility reasons with lazy integer variables.