### PR TITLE
Fixed issue with --no-learn flag

### DIFF
--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -314,7 +314,7 @@ inline bool Engine::constrain() {
     }
 #endif
   
-    if (so.parallel) {
+    if (so.parallel && so.lazy) {
         Lit p = opt_type ? opt_var->getLit(best_sol+1, 2) : opt_var->getLit(best_sol-1, 3);
         vec<Lit> ps;
         ps.push(p);
@@ -326,9 +326,17 @@ inline bool Engine::constrain() {
     //  printf("opt_var = %d, opt_type = %d, best_sol = %d\n", opt_var->var_id, opt_type, best_sol);
 //  printf("%% opt_var min = %d, opt_var max = %d\n", opt_var->getMin(), opt_var->getMax());
 
-    Lit p = opt_type ? opt_var->getLit(best_sol+1, 2) : opt_var->getLit(best_sol-1, 3);
-    assumptions.clear();
-    assumptions.push(toInt(p));
+    if (so.lazy) {
+        Lit p = opt_type ? opt_var->getLit(best_sol+1, 2) : opt_var->getLit(best_sol-1, 3);
+        assumptions.clear();
+        assumptions.push(toInt(p));
+    } else {
+        if (opt_type) { // maximize
+            if(!opt_var->setMin(best_sol+1)) return false;
+        } else {
+            if(!opt_var->setMax(best_sol-1)) return false;
+        }
+    }
 
     if (so.mip) mip->setObjective(best_sol);
 

--- a/chuffed/primitives/arithmetic.cpp
+++ b/chuffed/primitives/arithmetic.cpp
@@ -291,11 +291,14 @@ public:
 
         if (z_min_new > IntVar::min_limit) {
             // TODO Better explanation
-            Clause * reason = Reason_new(5);
-            (*reason)[1] = x.getMinLit();
-            (*reason)[2] = x.getMaxLit();
-            (*reason)[3] = y.getMinLit();
-            (*reason)[4] = y.getMaxLit();
+            Clause * reason = nullptr;
+            if (so.lazy) {
+              reason = Reason_new(5);
+              (*reason)[1] = x.getMinLit();
+              (*reason)[2] = x.getMaxLit();
+              (*reason)[3] = y.getMinLit();
+              (*reason)[4] = y.getMaxLit();
+            }
             setDom(z, setMin, z_min_new, reason);
         }
         
@@ -306,11 +309,14 @@ public:
         
         if (z_max_new < IntVar::max_limit) {
             // TODO Better explanation
-            Clause * reason = Reason_new(5);
-            (*reason)[1] = x.getMinLit();
-            (*reason)[2] = x.getMaxLit();
-            (*reason)[3] = y.getMinLit();
-            (*reason)[4] = y.getMaxLit();
+            Clause * reason = nullptr;
+            if (so.lazy) {
+              reason = Reason_new(5);
+              (*reason)[1] = x.getMinLit();
+              (*reason)[2] = x.getMaxLit();
+              (*reason)[3] = y.getMinLit();
+              (*reason)[4] = y.getMaxLit();
+            }
             setDom(z, setMax, z_max_new, reason);
         }
 
@@ -323,11 +329,14 @@ public:
             // The product z equals to 0. Then x must equal to 0 too if y cannot be 0.
             if (v_min > 0 || v_max < 0) {
                 // TODO Better explanation
-                Clause * reason = Reason_new(5);
-                (*reason)[1] = v.getMinLit();
-                (*reason)[2] = v.getMaxLit();
-                (*reason)[3] = z.getMinLit();
-                (*reason)[4] = z.getMaxLit();
+                Clause * reason = nullptr;
+                if (so.lazy) {
+                  reason = Reason_new(5);
+                  (*reason)[1] = v.getMinLit();
+                  (*reason)[2] = v.getMaxLit();
+                  (*reason)[3] = z.getMinLit();
+                  (*reason)[4] = z.getMaxLit();
+                }
                 setDom(u, setMin, 0, reason);
                 setDom(u, setMax, 0, reason);
             }
@@ -335,16 +344,22 @@ public:
         else if (z_min > 0) {
             if (v_min == 0) {
                 // TODO Better explanation
-                Clause * reason = Reason_new(3);
-                (*reason)[1] = z.getMinLit();
-                (*reason)[2] = v.getMinLit();
+                Clause * reason = nullptr;
+                if (so.lazy) {
+                  reason = Reason_new(3);
+                  (*reason)[1] = z.getMinLit();
+                  (*reason)[2] = v.getMinLit();
+                }
                 setDom(v, setMin, 1, reason);
             }
             else if (v_max == 0) {
                 // TODO Better explanation
-                Clause * reason = Reason_new(3);
-                (*reason)[1] = z.getMinLit();
-                (*reason)[2] = v.getMaxLit();
+                Clause * reason = nullptr;
+                if (so.lazy) {
+                  reason = Reason_new(3);
+                  (*reason)[1] = z.getMinLit();
+                  (*reason)[2] = v.getMaxLit();
+                }
                 setDom(v, setMax, -1, reason);
             }
             else {
@@ -357,16 +372,22 @@ public:
         else if (z_max < 0) {
             if (v_min == 0) {
                 // TODO Better explanation
-                Clause * reason = Reason_new(3);
-                (*reason)[1] = z.getMaxLit();
-                (*reason)[2] = v.getMinLit();
+                Clause * reason = nullptr;
+                if (so.lazy) {
+                  reason = Reason_new(3);
+                  (*reason)[1] = z.getMaxLit();
+                  (*reason)[2] = v.getMinLit();
+                }
                 setDom(v, setMin, 1, reason);
             }
             else if (v_max == 0) {
                 // TODO Better explanation
-                Clause * reason = Reason_new(3);
-                (*reason)[1] = z.getMaxLit();
-                (*reason)[2] = v.getMaxLit();
+                Clause * reason = nullptr;
+                if (so.lazy) {
+                  reason = Reason_new(3);
+                  (*reason)[1] = z.getMaxLit();
+                  (*reason)[2] = v.getMaxLit();
+                }
                 setDom(v, setMax, -1, reason);
             }
             else {
@@ -417,11 +438,14 @@ public:
 
         if (u_min_new > u.getMin()) {
             // TODO Better explanation
-            Clause * reason = Reason_new(5);
-            (*reason)[1] = v.getMinLit();
-            (*reason)[2] = v.getMaxLit();
-            (*reason)[3] = z.getMinLit();
-            (*reason)[4] = z.getMaxLit();
+            Clause * reason = nullptr;
+            if (so.lazy) {
+              reason = Reason_new(5);
+              (*reason)[1] = v.getMinLit();
+              (*reason)[2] = v.getMaxLit();
+              (*reason)[3] = z.getMinLit();
+              (*reason)[4] = z.getMaxLit();
+            }
             setDom(u, setMin, (u_min_new == 0 ? 1 : u_min_new), reason);
         }
 
@@ -447,11 +471,14 @@ public:
 
         if (u_max_new < u.getMax()) {
             // TODO Better explanation
-            Clause * reason = Reason_new(5);
-            (*reason)[1] = v.getMinLit();
-            (*reason)[2] = v.getMaxLit();
-            (*reason)[3] = z.getMinLit();
-            (*reason)[4] = z.getMaxLit();
+            Clause * reason = nullptr;
+            if (so.lazy) {
+              reason = Reason_new(5);
+              (*reason)[1] = v.getMinLit();
+              (*reason)[2] = v.getMaxLit();
+              (*reason)[3] = z.getMinLit();
+              (*reason)[4] = z.getMaxLit();
+            }
             setDom(u, setMax, (u_max_new == 0 ? -1 : u_max_new), reason);
         }
 


### PR DESCRIPTION
Fixed issue in search engine and TimesAll propagaor where the `--no-learn` (`so.lazy`) flag was ignored and Chuffed tried to access non-existing literals, causing a crash.