### PR TITLE
Allow Chuffed to be embedded as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,5 +330,39 @@ file(RELATIVE_PATH REL_INSTALL_BINARY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DA
 configure_file(chuffed.msc.in chuffed.msc)
 
 install(TARGETS fzn-chuffed RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS chuffed chuffed_fzn
+  EXPORT chuffed-targets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+  DIRECTORY chuffed
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h"
+)
 install(DIRECTORY chuffed/flatzinc/mznlib/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/minizinc/chuffed PATTERN "chuffed/flatzinc/mznlib/*")
 install(FILES ${CMAKE_BINARY_DIR}/chuffed.msc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/minizinc/solvers)
+
+# ------------- CMake export configuration -------------
+include(CMakePackageConfigHelpers)
+
+export(EXPORT chuffed-targets FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/chuffed-targets.cmake)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/chuffed-config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/chuffed-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/chuffed
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/chuffed-config-version.cmake"
+  VERSION "${chuffed_VERSION_MAJOR}.${chuffed_VERSION_MINOR}.${chuffed_VERSION_PATCH}"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(EXPORT chuffed-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/chuffed)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/chuffed-config.cmake"
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/chuffed-config-version.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/chuffed
+)

--- a/chuffed-config.cmake.in
+++ b/chuffed-config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/chuffed-targets.cmake")
+
+check_required_components(chuffed chuffed_fzn)
+
+set(CHUFFED_LIBRARIES chuffed chuffed_fzn)
+set(CHUFFED_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR})
+set(CHUFFED_FOUND TRUE)

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -222,6 +222,7 @@ Engine::Engine()
     , solutions(0)
     , next_simp_db(0)
     , output_stream(&std::cout)
+    , solution_callback(nullptr)
 #ifdef HAS_VAR_IMPACT
 	, last_int(nullptr)
 #endif
@@ -851,6 +852,9 @@ RESULT Engine::search(const std::string& problemLabel) {
                     problem->print(*output_stream);
                     (*output_stream) << "\n----------\n";
                     output_stream->flush();
+                }
+                if (solution_callback) {
+                    solution_callback(problem);
                 }
 #if DEBUG_VERBOSE
                 std::cerr << "solution\n";

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -3,6 +3,7 @@
 
 #include <chuffed/support/misc.h>
 #include <string>
+#include <functional>
 
 #define DEBUG 0
 
@@ -74,6 +75,7 @@ public:
     int restart_count;
 
     std::ostream* output_stream;
+    std::function<void(Problem* p)> solution_callback;
 private:
 
     // Init
@@ -127,6 +129,9 @@ public:
         output_stream = &os;
     }
     
+    void setSolutionCallback(std::function<void(Problem*)> f) {
+        solution_callback = std::move(f);
+    }
 };
 
 extern Engine engine;

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -131,7 +131,7 @@ namespace FlatZinc {
 
     void FlatZincSpace::newBoolVar(BoolVarSpec* vs) {
         // Resizing of the vectors if required
-        if (boolVarCount == iv.size()) {
+        if (boolVarCount == bv.size()) {
             const int newSize = boolVarCount > 0 ? 2 * boolVarCount : 1;
             bv.growTo(newSize);
             bv_introduced.resize(newSize);


### PR DESCRIPTION
This pull request modifies the CMake configuration to allow `find_package(chuffed)` to work in order to embed Chuffed in another application.

The current use case is that the WebAssembly version of MiniZinc is much easier to use if solvers can be statically linked into MiniZinc, as this avoids having to emulate communication between processes. To make this work, a solution callback option is also added to the engine so that MiniZinc can trigger solution printing at the correct time.