### PR TITLE
Fix a decomposition of fzn_arg_max_bool

### DIFF
--- a/chuffed/flatzinc/mznlib/fzn_arg_max_bool.mzn
+++ b/chuffed/flatzinc/mznlib/fzn_arg_max_bool.mzn
@@ -1,4 +1,8 @@
 predicate chuffed_maximum_arg_bool(array[int] of var bool: x, int: offset, var int: y);
 
 predicate fzn_maximum_arg_bool(array[int] of var bool: x, var int: i) =
-  chuffed_maximum_arg_bool(x,min(index_set(x)),i);
+  let { 
+    set of int: ii = index_set(x);
+    var min(ii)..max(ii)+1: idx;
+    constraint if idx > max(ii) then i = min(ii) else i = idx endif;
+  } in chuffed_maximum_arg_bool(x ++ [true], min(ii), idx);


### PR DESCRIPTION
The propagator assumes that at least one of the values in the array should be true, but this is not required in MiniZinc. This commit ensures MiniZinc rewrites the constraints so it works. In the future, it likely would be better to change the propagator

Temporary workaround for #90