### PR TITLE
Warm Start and Assumption Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chuffed, a lazy clause generation solver
+# Chuffed, a lazy clause generation solver 
 
 Geoffrey Chu, Peter J. Stuckey, Andreas Schutt, Thorsten Ehlers, Graeme Gange, Kathryn Francis
 
@@ -46,9 +46,16 @@ To build the C++ examples:
     cmake ..
     cmake --build . --target examples
 
-To build a debug or release, chosen by default, version use the following command instead of `cmake ..`:
+### Assumption interface
+Chuffed has FlatZinc hooks to the internal assumption handling. By adding an
+`assume(array [int] of var bool)` annotation to a solve item, the specified Booleans
+will be treated as assumptions. This annotation can be used when chuffed's solver
+specific definitions are included (i.e., by adding `include "chuffed.mzn";` to your
+MiniZinc model).
 
-    cmake -DCMAKE_BUILD_TYPE=[Debug|Release] ..
+If the resulting problem is unsatisfiable (or the optimum is found), the solver will
+print a valid -- though not necessarily minimal -- nogood in terms of assumptions
+(and, for optimization instances, an objective bound).
 
 #### Integration with CP Profiler
 

--- a/chuffed.msc.in
+++ b/chuffed.msc.in
@@ -27,6 +27,7 @@
     ["--sort-learnt-level", "Sort literals in a learnt clause based on their decision level", "bool", "false"],
     ["--one-watch", "Watch only one literal in a learn clause", "bool:on:off", "true"],
     ["--bin-clause-opt", "Optimise learnt clauses of length 2", "bool:on:off", "true"],
+    ["--assump-int", "Try and convert assumptions from the assumption interface back to integer domain expressions", "bool:on:off", "false"],
     ["--introduced-heuristic", "Decide if variable is introduced based on its name", "bool", "false"],
     ["--use-var-is-introduced", "Decide if variable is introduced based on var_is_introduced annotation", "bool", "false"],
     ["--exclude-introduced", "Exclude introduced variables from learnt clauses", "bool", "false"],

--- a/chuffed/branching/warm-start.h
+++ b/chuffed/branching/warm-start.h
@@ -1,0 +1,69 @@
+#ifndef CHUFFED_WARMSTART__H
+#define CHUFFED_WARMSTART__H
+#include <chuffed/branching/branching.h>
+
+// Warm-start brancher.
+// Once activated, it optimistically branches on the given literals
+// in order. It de-activates itself as soon as the first (post-activation) conflict
+// is hit.
+
+class WarmStartBrancher : public Branching {
+public:
+  WarmStartBrancher(vec<Lit>& _decs, bool _revive = false)
+    : decs(_decs), revive(_revive), init_conflicts(INT_MAX) {
+
+  }
+
+  WarmStartBrancher(vec<IntVar*> xs, vec<int>& vs, bool _revive = false)
+    : revive(_revive), init_conflicts(INT_MAX) {
+     
+  }
+    
+	bool finished() {
+    // Already deactivated
+    if(engine.conflicts > init_conflicts)
+      return true;
+
+    if(pos < decs.size()) {
+      if(sat.value(decs[pos]) == l_Undef)
+        return false;
+      if(engine.conflicts < init_conflicts)
+        trailSave(pos);
+      for(++pos; pos < decs.size(); ++pos) {
+        if(sat.value(decs[pos]) == l_Undef) 
+          return false;
+      }
+    }
+    return true;
+  }
+
+	double getScore(VarBranch vb) { NEVER; }
+
+	DecInfo* branch() {
+    // Check if this is the first activation
+    if(engine.conflicts < init_conflicts) {
+      if(revive) {
+        trailSave(init_conflicts);
+        trailSave(pos);
+      }
+      init_conflicts = engine.conflicts;
+    }
+    if(engine.conflicts == init_conflicts && pos < decs.size()) {
+      for(; pos < decs.size(); ++pos) {
+        if(sat.value(decs[pos]) == l_Undef) {
+          return new DecInfo(nullptr, toInt(decs[pos]));
+        }
+      }
+    }
+    return nullptr;
+  }
+
+protected:
+  vec<Lit> decs; // Decisions to make
+  int pos; // Current position
+  bool revive; // Should be brancher be revived 
+
+
+  int init_conflicts; // Number of conflicts at time of activation.
+};
+#endif

--- a/chuffed/branching/warm-start.h
+++ b/chuffed/branching/warm-start.h
@@ -10,12 +10,12 @@
 class WarmStartBrancher : public Branching {
 public:
   WarmStartBrancher(vec<Lit>& _decs, bool _revive = false)
-    : decs(_decs), revive(_revive), init_conflicts(INT_MAX) {
+    : decs(_decs), pos(0), revive(_revive), init_conflicts(INT_MAX) {
 
   }
 
   WarmStartBrancher(vec<IntVar*> xs, vec<int>& vs, bool _revive = false)
-    : revive(_revive), init_conflicts(INT_MAX) {
+    : revive(_revive), pos(0), init_conflicts(INT_MAX) {
      
   }
     

--- a/chuffed/core/assume.h
+++ b/chuffed/core/assume.h
@@ -1,0 +1,73 @@
+#ifndef assume_h
+#define assume_h
+#include <chuffed/support/misc.h>
+#include <chuffed/core/sat-types.h>
+#include <chuffed/core/sat.h>
+
+// Helper for pushing a failure back to externally visible literals.
+template<class P>
+void pushback_reason(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
+  assert(sat.value(p) == l_False);
+  out_nogood.push(~p);
+
+  // TODO: Take literal subsumption into account.
+  // Even though we can't _export_ integer bounds, we can still
+  // use the semantics to weaken the nogood.
+  vec<Lit> removed;
+  assert(!sat.reason[var(p)].isLazy()); 
+  if(sat.trailpos[var(p)] < 0) {
+    return; // p is false at the root.
+  }
+  
+  Clause* cp = sat.getExpl(~p);
+  if(!cp) {
+    // Somebody has pushed inconsistent assumptions.
+    // * This may happen if, in an optimization problem, the user
+    // * provided an objective lower bound which is achieved.
+
+    // If p and ~p are assumptions, we just return a
+    // tautological clause.
+    out_nogood.push(p);
+    return;
+  } else {
+    // Otherwise, fill in the reason for ~p...
+    for(int i = 1; i < cp->size(); i++) {
+      Lit q((*cp)[i]);
+      if(sat.trailpos[var(q)] < 0)
+        continue;
+      out_nogood.push(q);
+      // Only look at the first bit of seen, because
+      // we're using the second bit for assumption-ness.
+      sat.seen[var(q)] |= 1;
+    }
+    // then push it back to assumptions.
+    for(int i = 1; i < out_nogood.size(); i++) {
+      Lit q(out_nogood[i]);
+      if(is_extractable(q)) continue;
+      assert(!sat.reason[var(q)].isLazy());
+      Clause& c = *sat.getExpl(~q);
+      assert(&c != nullptr);
+      removed.push(q);
+      out_nogood[i] = out_nogood.last();
+      out_nogood.pop();
+      --i;
+
+      for(int j = 1; j < c.size(); j++) {
+        Lit r(c[j]);
+        if(!(sat.seen[var(r)]&1)) {
+          sat.seen[var(r)] |= 1;
+          if(sat.trailpos[var(r)] < 0)
+            removed.push(r);
+          else
+            out_nogood.push(r);
+        }
+      }
+    }
+  }
+  // Clear the 'seen' bit.
+	for (int i = 0; i < removed.size(); i++) sat.seen[var(removed[i])] &= (~1);
+  for (int i = 1; i < out_nogood.size(); i++) sat.seen[var(out_nogood[i])] &= (~1);
+}
+
+
+#endif

--- a/chuffed/core/assume.h
+++ b/chuffed/core/assume.h
@@ -46,15 +46,15 @@ void pushback_reason(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
       Lit q(out_nogood[i]);
       if(is_extractable(q)) continue;
       assert(!sat.reason[var(q)].isLazy());
-      Clause& c = *sat.getExpl(~q);
-      assert(&c != nullptr);
+      Clause* c = sat.getExpl(~q);
+      assert(c != nullptr);
       removed.push(q);
       out_nogood[i] = out_nogood.last();
       out_nogood.pop();
       --i;
 
-      for(int j = 1; j < c.size(); j++) {
-        Lit r(c[j]);
+      for(int j = 1; j < c->size(); j++) {
+        Lit r((*c)[j]);
         if(!(sat.seen[var(r)]&1)) {
           sat.seen[var(r)] |= 1;
           if(sat.trailpos[var(r)] < 0)

--- a/chuffed/core/assume.h
+++ b/chuffed/core/assume.h
@@ -5,6 +5,7 @@
 #include <chuffed/core/sat.h>
 
 // Helper for pushing a failure back to externally visible literals.
+// WARNING: This assumes explanations are not lazy.
 template<class P>
 void pushback_reason(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
   assert(sat.value(p) == l_False);
@@ -67,6 +68,136 @@ void pushback_reason(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
   // Clear the 'seen' bit.
 	for (int i = 0; i < removed.size(); i++) sat.seen[var(removed[i])] &= (~1);
   for (int i = 1; i < out_nogood.size(); i++) sat.seen[var(out_nogood[i])] &= (~1);
+}
+
+// General version, which permits lazy explanations.
+// Basically a mix of pushback and normal conflict analysis.
+template<class Pred>
+void pushback_reason_lazy(const Pred& is_extractable, Lit p, vec<Lit>& out_nogood) {
+  assert(sat.value(p) == l_False);
+  out_nogood.push(~p);
+  // TODO: Take literal subsumption into account.
+  // Even though we can't _export_ integer bounds, we can still
+  // use the semantics to weaken the nogood.
+  vec<Lit> removed;
+  if(sat.trailpos[var(p)] < 0) {
+    return; // p is false at the root.
+  }
+
+  Clause* cp = sat.getExpl(~p);
+  if(!cp) {
+    // Somebody has pushed inconsistent assumptions.
+    // * This may happen if, in an optimization problem, the user
+    // * provided an objective lower bound which is achieved.
+
+    // If p and ~p are assumptions, we just return a
+    // tautological clause.
+    out_nogood.push(p);
+    return;
+  }
+
+  // There _should_ be at least one atom at the current decision level.
+  int pending = 0;
+  for(int jj = 1; jj < (*cp).size(); ++jj) {
+    Lit p((*cp)[jj]);
+    assert(sat.value(p) == l_False);
+
+    sat.seen[var(p)] |= 1;
+    if(sat.trailpos[var(p)] < 0) {
+      removed.push(p); // If trailpos < 0, not needed.
+    } else {
+      pending++;
+    }
+  }
+  assert(pending > 0);
+  if(pending == 0)
+    return;
+
+  // Process the levels in order.
+  Reason last_reason = sat.reason[var(p)];
+
+  int lev = sat.decisionLevel();
+  // Should never need to touch level 0.
+  while(lev > 0) {
+	  vec<Lit>& ctrail = sat.trail[lev];
+
+    int& index = sat.index;
+    index = ctrail.size();
+    while(index) {
+      // Skip variables we haven't seen
+      if(!(sat.seen[var(ctrail[--index])]&1))
+        continue;
+      
+      // Found the next literal.
+      Lit p(ctrail[index]);
+      pending--;
+
+      assert(sat.value(p) == l_True);
+      if(is_extractable(p)) {
+        // p is an assumption.
+        // See if we can drop it anyway.
+        Clause* expl(sat.getExpl(p));
+        if(!expl) {
+          out_nogood.push(~p);
+        } else {
+          // If every antecedent is already seen, we don't need it.
+          for(int j = 1; j < (*expl).size(); ++j) {
+            if(!(sat.seen[var((*expl)[j])]&1)) {
+              // Needed after all
+              out_nogood.push(~p);
+              goto processed_assump;
+            }
+          }
+          // Remember to reset seen at the end.
+          removed.push(p);
+        }
+processed_assump:
+        // Have we seen enough?
+        if(!pending)
+          goto pushback_finished;
+        continue;
+      }
+
+      // Not an assumption; mark the antecedents as seen.
+      assert(var(p) >= 0 && var(p) < sat.nVars());
+
+      // Sign doesn't really matter here; just the var.
+      removed.push(p);
+
+      if (last_reason == sat.reason[var(p)]) continue;
+      last_reason = sat.reason[var(p)];
+
+      Clause& c = *sat.getExpl(p);
+      assert(&c);
+
+      for (int j = 1; j < c.size(); j++) {
+        Lit q = c[j];
+        if (!(sat.seen[var(q)]&1)) {
+          sat.seen[var(q)] |= 1;
+          assert(sat.value(q) == l_False);
+          assert(sat.trailpos[var(q)] <= engine.trail.size());
+          if(sat.trailpos[var(q)] < 0) {
+            removed.push(q);
+          } else {
+            pending++;
+          }
+        }
+      }
+      assert(pending > 0);
+    }
+    // Finished at the current level.
+    lev--;
+    // We need to explicitly backtrack, because
+    // getExpl calls btToPos, which accesses the _current_
+    // decision level's trail.
+    sat.btToLevel(lev);
+  }
+
+pushback_finished:
+  assert(pending == 0);
+
+	for (int i = 0; i < removed.size(); i++) sat.seen[var(removed[i])] &= (~1);
+	for(int i = 0; i < out_nogood.size(); i++) sat.seen[var(out_nogood[i])] &= (~1);
 }
 
 

--- a/chuffed/core/conflict.cpp
+++ b/chuffed/core/conflict.cpp
@@ -6,6 +6,7 @@
 #include <chuffed/core/sat.h>
 #include <chuffed/core/propagator.h>
 #include <chuffed/ldsb/ldsb.h>
+#include <chuffed/core/assume.h>
 
 #include <iostream>
 #include <fstream>
@@ -399,6 +400,61 @@ void SAT::explainUnlearnable(std::set<int>& contributingNogoods) {
 	for (int i = 0; i < removed.size(); i++) seen[var(removed[i])] = 0;
 
 	pushback_time += std::chrono::duration_cast<duration>(chuffed_clock::now() - start);
+}
+
+template<class P>
+void push_back(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
+  assert(sat.value(p) == l_False);
+  
+  out_nogood.push(~p);
+
+  vec<Lit> removed;
+  assert(!sat.reason[var(p)].isLazy()); 
+  Clause* cp = sat.getExpl(~p);
+  if(!cp) {
+    // Two possibilities here: either p is false at the root,
+    // or somebody pushed inconsistent assumptions.
+    // * This may happen if, in an optimization problem, the user
+    // * provided an objective lower bound which is achieved.
+    if(sat.trailpos[var(p)] >= 0) {
+      // If p and ~p are assumptions, we just return a
+      // tautological clause.
+      out_nogood.push(p);
+    }
+    return;
+  } else {
+    // Otherwise, fill in the reason for ~p...
+    for(int i = 1; i < cp->size(); i++) {
+      Lit q((*cp)[i]);
+      out_nogood.push(q);
+      // Only look at the first bit of seen, because
+      // we're using the second bit for assumption-ness.
+      sat.seen[var(q)] |= 1;
+    }
+    // then push it back to assumptions.
+    for(int i = 1; i < out_nogood.size(); i++) {
+      Lit q(out_nogood[i]);
+      if(is_extractable(q)) continue;
+      assert(!sat.reason[var(p)].isLazy());
+      Clause& c = *sat.getExpl(~q);
+      assert(&c != nullptr);
+      removed.push(q);
+      out_nogood[i] = out_nogood.last();
+      out_nogood.pop();
+      --i;
+
+      for(int j = 1; j < c.size(); j++) {
+        Lit r(c[j]);
+        if(!(sat.seen[var(r)]&1)) {
+          sat.seen[var(r)] = true;
+          out_nogood.push(r);
+        }
+      }
+    }
+  }
+  // Clear the 'seen' bit.
+	for (int i = 0; i < removed.size(); i++) sat.seen[var(removed[i])] &= (~1);
+  for (int i = 1; i < out_nogood.size(); i++) sat.seen[var(out_nogood[i])] &= (~1);
 }
 
 void SAT::explainToExhaustion(std::set<int>& contributingNogoods) {

--- a/chuffed/core/conflict.cpp
+++ b/chuffed/core/conflict.cpp
@@ -436,15 +436,15 @@ void push_back(const P& is_extractable, Lit p, vec<Lit>& out_nogood) {
       Lit q(out_nogood[i]);
       if(is_extractable(q)) continue;
       assert(!sat.reason[var(p)].isLazy());
-      Clause& c = *sat.getExpl(~q);
-      assert(&c != nullptr);
+      Clause* c = sat.getExpl(~q);
+      assert(c != nullptr);
       removed.push(q);
       out_nogood[i] = out_nogood.last();
       out_nogood.pop();
       --i;
 
-      for(int j = 1; j < c.size(); j++) {
-        Lit r(c[j]);
+      for(int j = 1; j < c->size(); j++) {
+        Lit r((*c)[j]);
         if(!(sat.seen[var(r)]&1)) {
           sat.seen[var(r)] = true;
           out_nogood.push(r);

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -564,7 +564,8 @@ void Engine::retrieve_assumption_nogood(vec<BoolView>& xs) {
   }
 
   // Collect the nogood.
-  pushback_reason([](Lit p) { return sat.seen[var(p)]&2; }, q, out_nogood);
+  // pushback_reason([](Lit p) { return sat.seen[var(p)]&2; }, q, out_nogood);
+  pushback_reason_lazy([](Lit p) { return sat.seen[var(p)]&2; }, q, out_nogood);
   
   for(int ii = 0; ii < out_nogood.size(); ii++)
     xs.push(out_nogood[ii]);

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -21,6 +21,7 @@ class Problem;
 class Propagator;
 class PseudoProp;
 class TrailElem;
+class BoolView;
 
 //-----
 
@@ -113,6 +114,9 @@ public:
     // Interface methods
     RESULT search(const std::string& problemLabel = "chuffed");
     void solve(Problem *p, const std::string& problemLabel = "chuffed");
+
+    void set_assumptions(vec<BoolView>& xs);
+    void retrieve_assumption_nogood(vec<BoolView>& xs);
 
     // Stats
     void printStats();

--- a/chuffed/core/engine.h
+++ b/chuffed/core/engine.h
@@ -167,6 +167,16 @@ static inline void trailChange(T& v, const U u) {
     v = u;
 }
 
+// Like trailChange, but don't actually update the value.
+template<class T>
+static inline void trailSave(T& v) {
+  int *pt = (int*) &v;
+  engine.trail.push(TrailElem(pt, sizeof(T)));
+  if (sizeof(T) == 8) {
+    engine.trail.push(TrailElem(pt+1, sizeof(T)));
+  }
+}
+
 
 
 //------

--- a/chuffed/core/options.cpp
+++ b/chuffed/core/options.cpp
@@ -94,6 +94,7 @@ Options::Options() :
 
 	, alldiff_cheat(true)
 	, alldiff_stage(true)
+  , assump_int(false)
 #ifdef HAS_PROFILER
   , cpprofiler_enabled(false)
   , cpprofiler_id(-1)
@@ -335,6 +336,8 @@ void printLongHelp(int& argc, char**& argv, const std::string& fileExt) {
   "     Watch only one literal in a learn clause (default " << (def.one_watch ? "on" : "off") << ").\n"
   "  --bin-clause-opt [on|off], --no-bin-clause-opt\n"
   "     Optimise learnt clauses of length 2 (default " << (def.bin_clause_opt ? "on" : "off") << ").\n"
+  "  --assump-int [on|off], --no-assump-int\n"
+  "     Try and convert assumptions from the assumption interface back to integer domain expressions (default " << (def.assump_int ? "on" : "off") << ").\n"
   "\n"
   "Introduced Variable Options:\n"
   "  --introduced-heuristic [on|off], --no-introduced-heuristic\n"
@@ -539,6 +542,8 @@ void parseOptions(int& argc, char**& argv, std::string* fileArg, const std::stri
       so.exhaustive_activity = boolBuffer;
     } else if (cop.getBool("--bin-clause-opt", boolBuffer)) {
       so.bin_clause_opt = boolBuffer;
+    } else if (cop.getBool("--assump-int", boolBuffer)) {
+      so.assump_int = boolBuffer;
     } else if (cop.get("--eager-limit", &intBuffer)) {
       so.eager_limit = intBuffer;
     } else if (cop.get("--sat-var-limit", &intBuffer)) {

--- a/chuffed/core/options.h
+++ b/chuffed/core/options.h
@@ -135,6 +135,8 @@ public:
 	bool alldiff_cheat;              // if n vars over n vals, enforce that all vals are taken
 	bool alldiff_stage;              // if bounds or domain consistency, put value propagator too
 
+    bool assump_int;                 // Try and convert assumptions back to integer domain expressions.
+
 #ifdef HAS_PROFILER
   // CP Profiler
   bool cpprofiler_enabled;

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -310,7 +310,7 @@ namespace FlatZinc {
 
     void FlatZincSpace::parseSolveAnnWarmStart(AST::Node* elemAnn, BranchGroup* branching, int& nbNonEmptySearchAnnotations) {
         vec<Lit> decs;
-        AST::Call *call = elemAnn->getCall("warm_start");
+        AST::Call *call = elemAnn->getCall("warm_start_int");
         /*
         AST::Array* vars = call->args->getArray();
         for(int ii = 0; ii < vars->a.size(); ii++)
@@ -320,7 +320,7 @@ namespace FlatZinc {
         AST::Array* vars = args->a[0]->getArray();
         AST::Array* vals = args->a[1]->getArray();
         if(vars->a.size() != vals->a.size()) {
-            fprintf(stderr, "WARNING: length mismatch in warm_start annotation.\n");
+            fprintf(stderr, "WARNING: length mismatch in warm_start_int annotation.\n");
         }
         int sz = min(vars->a.size(), vals->a.size());
         for(int ii = 0; ii < sz; ii++) {
@@ -351,7 +351,7 @@ namespace FlatZinc {
         }
         else if (elemAnn->isCall("priority_search")) {
             parseSolveAnnPrioritySearch(elemAnn, branching, nbNonEmptySearchAnnotations);    
-        } else if (elemAnn->isCall("warm_start")) {
+        } else if (elemAnn->isCall("warm_start_int")) {
             parseSolveAnnWarmStart(elemAnn, branching, nbNonEmptySearchAnnotations);
         }
         else {

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -326,6 +326,7 @@ namespace FlatZinc {
 
     // Entry function for parsing the solve annotation
     void FlatZincSpace::parseSolveAnn(AST::Array* ann) {
+        assumptions.clear();
         int nbNonEmptySearchAnnotations = 0;
         try {
             // Parse the search annotation

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -373,6 +373,12 @@ namespace FlatZinc {
                         CHUFFED_ERROR("Illegal restart base. Restart count will converge to zero.");
                     }
                     if (so.restart_scale_override) { so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt()); }
+                } else if (ann->a[i]->isCall("assume")) {
+                    AST::Call *call = flatAnn[i]->getCall("assume");
+                    AST::Array *vars = call->args->getArray();
+                    for(int ii = 0; ii < vars->a.size(); ii++) {
+                        assumptions.push(bv[vars->a[ii]->getBoolVar()]);
+                    }
                 } else if (ann->a[i]->isCall("seq_search")) {
                     // Get the call
                     AST::Call* c = ann->a[i]->getCall();

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -24,6 +24,7 @@
 #include <chuffed/flatzinc/flatzinc.h>
 #include <chuffed/core/engine.h>
 #include <chuffed/branching/branching.h>
+#include <chuffed/branching/warm-start.h>
 
 
 using namespace std;
@@ -380,6 +381,14 @@ namespace FlatZinc {
                     for(int ii = 0; ii < vars->a.size(); ii++) {
                         assumptions.push(bv[vars->a[ii]->getBoolVar()]);
                     }
+                } else if (ann->a[i]->isCall("warm_start")) {
+                    vec<Lit> decs;
+                    AST::Call *call = flatAnn[i]->getCall("warm_start");
+                    AST::Array* vars = call->args->getArray();
+                    for(int ii = 0; ii < vars->a.size(); ii++) {
+                        decs.push(bv[vars->a[ii]->getBoolVar()].getLit(1));
+                    }
+                    engine.branching->add(new WarmStartBrancher(decs));
                 } else if (ann->a[i]->isCall("seq_search")) {
                     // Get the call
                     AST::Call* c = ann->a[i]->getCall();

--- a/chuffed/flatzinc/flatzinc.h
+++ b/chuffed/flatzinc/flatzinc.h
@@ -440,6 +440,7 @@ namespace FlatZinc {
         void parseSolveAnnIntSearch(AST::Node* elemAnn, BranchGroup* branching, int& nbNonEmptySearchAnnotations);
         void parseSolveAnnBoolSearch(AST::Node* elemAnn, BranchGroup* branching, int& nbNonEmptySearchAnnotations);
         void parseSolveAnnPrioritySearch(AST::Node* elemAnn, BranchGroup* branching, int& nbNonEmptySearchAnnotations);
+        void parseSolveAnnWarmStart(AST::Node* elemAnn, BranchGroup* branching, int& nbNonEmptySearchAnnotations);
     };
 
     extern FlatZincSpace *s;

--- a/chuffed/flatzinc/flatzinc.h
+++ b/chuffed/flatzinc/flatzinc.h
@@ -271,6 +271,8 @@ namespace FlatZinc {
         /// Indicates whether a Boolean variable is introduced by mzn2fzn
         std::vector<bool> bv_introduced;
 
+        vec<BoolView> assumptions;
+
         AST::Array* output;
 
         /// Construct problem with given number of variables

--- a/chuffed/flatzinc/fzn-chuffed.cpp
+++ b/chuffed/flatzinc/fzn-chuffed.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <csignal>
 #include <cstring>
+#include <sstream>
 #include <chuffed/core/options.h>
 #include <chuffed/core/engine.h>
 #include <chuffed/flatzinc/flatzinc.h>
@@ -39,6 +40,67 @@ std::stringstream output_buffer;
 	}
 #endif
 
+const char* irel_str[] = { " = ", " != ", " <= ", " > " };
+ 
+std::string get_bv_string(BoolView b) {
+  std::string s;
+  
+#if 0  
+  // Alternate version: prioritise intvars.
+  Lit l(b.getLit(true));
+  ChannelInfo ci(sat.c_info[var(l)]);
+  if(ci.cons_type == 1 && !(s = intVarString[engine.vars[ci.cons_id]]).empty()) {
+    // Int literal
+    std::stringstream ss;
+    ss << s;
+    ss << irel_str[2 * ci.cons_type + b.getSign()];
+    ss << ci.val;
+    return ss.str();
+  } else {
+    s = boolVarString[b];
+    if(s.empty()) {
+      BoolView o(b);
+      o.setSign(!o.getSign());
+      std::string ostring = boolVarString[o];
+      if(!ostring.empty()) {
+        s = "~ " + ostring;
+      } else {
+        s = "<UNKNOWN>";
+      }
+    }
+    return s;
+  }
+#else
+  // See if b or ~b have names.
+  std::string bvstring = boolVarString[b];
+  if(bvstring.empty()) {
+    BoolView o(b);
+    o.setSign(!o.getSign());
+    std::string ostring = boolVarString[o];
+    if (ostring.empty()) {
+      // Maybe it's attached to a (named) intvar.
+      Lit l(b.getLit(true));
+      ChannelInfo ci(sat.c_info[var(l)]);
+      std::string ivstring;
+      if(ci.cons_type == 1 && !(ivstring = intVarString[engine.vars[ci.cons_id]]).empty()) {
+        // If it is, return the denotation of b.
+        std::stringstream ss;
+        ss << ivstring;
+        ss << irel_str[2 * ci.cons_type + b.getSign()];
+        ss << ci.val;
+        return ss.str();
+      } else {
+        return "<UNKNOWN>";
+      }
+    } else {
+      return "~ " + ostring;
+    }
+  } else {
+    return bvstring;
+  }
+#endif
+}
+
 int main(int argc, char** argv) {
     // Make a copy of the arguments for posterity.
     std::string commandLine;
@@ -75,12 +137,26 @@ int main(int argc, char** argv) {
 	std::signal(SIGINT, SIGINT_handler);
 #endif
 
+  engine.set_assumptions(FlatZinc::s->assumptions);
   if (engine.opt_var && so.nof_solutions!=0) {
     engine.setOutputStream(output_buffer);
     engine.solve(FlatZinc::s, commandLine);
     std::cout << output_buffer.str();
   } else {
     engine.solve(FlatZinc::s, commandLine);
+  }
+
+  if(engine.status == RES_LUN) {
+    vec<BoolView> ng;
+    engine.retrieve_assumption_nogood(ng);
+    std::cout << "% [";
+    if(ng.size() > 0) {
+      std::cout << get_bv_string(ng[0]);
+      for(int ii = 1; ii < ng.size(); ii++) {
+        std::cout << ", " << get_bv_string(ng[ii]);
+      }
+    }
+    std::cout << "]" << std::endl;
   }
 
 	return 0;

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -57,6 +57,3 @@ annotation largest_smallest;
 
 /** @group chuffed.annotations annotation for assumption handling. */
 annotation assume(array [int] of var bool);
-
-/** @group chuffed.annotations annotation for warm-start. */
-annotation warm_start(array [int] of var bool: decs);

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -57,3 +57,6 @@ annotation largest_smallest;
 
 /** @group chuffed.annotations annotation for assumption handling. */
 annotation assume(array [int] of var bool);
+
+/** @group chuffed.annotations annotation for warm-start. */
+annotation warm_start(array [int] of var bool: decs);

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -54,3 +54,6 @@ annotation smallest_largest;
 
 /** @group chuffed.annotations Choose the variable with the largest smallest value in its domain */
 annotation largest_smallest;
+
+/** @group chuffed.annotations annotation for assumption handling. */
+annotation assume(array [int] of var bool);

--- a/chuffed/flatzinc/mznlib/redefinitions.mzn
+++ b/chuffed/flatzinc/mznlib/redefinitions.mzn
@@ -100,9 +100,8 @@ predicate int_lt_imp(var int: a, var int: b, var bool: r);
 % `warm_start` annotation is overloaded on the FlatZinc level, the following
 % definitions disambiguate these annotations within Chuffed.
 
-%%% TODO: Directly support warm start on Booleans!
-% annotation warm_start_bool(array[int] of var bool: x, array[int] of bool: v);
-annotation warm_start(array[int] of var bool: x, array[int] of bool: v) = warm_start_int([bool2int(xi) | xi in x], [bool2int(vi) | vi in v]);
+annotation warm_start_bool(array[int] of var bool: x, array[int] of bool: v);
+annotation warm_start(array[int] of var bool: x, array[int] of bool: v) = warm_start_bool(x, v);
 annotation warm_start_int(array[int] of var int: x, array[int] of int: v);
 annotation warm_start(array[int] of var int: x, array[int] of int: v) = warm_start_int(x, v);
 annotation warm_start_float(array[int] of var float: x, array[int] of float: v);

--- a/chuffed/flatzinc/mznlib/redefinitions.mzn
+++ b/chuffed/flatzinc/mznlib/redefinitions.mzn
@@ -96,3 +96,14 @@ predicate int_gt_imp(var int: a, var int: b, var bool: r);
 predicate int_le_imp(var int: a, var int: b, var bool: r);
 predicate int_lt_imp(var int: a, var int: b, var bool: r);
 
+%%% NOTE: because of a mistake in the MiniZinc standard library, the
+% `warm_start` annotation is overloaded on the FlatZinc level, the following
+% definitions disambiguate these annotations within Chuffed.
+
+%%% TODO: Directly support warm start on Booleans!
+% annotation warm_start_bool(array[int] of var bool: x, array[int] of bool: v);
+annotation warm_start(array[int] of var bool: x, array[int] of bool: v) = warm_start_int([bool2int(xi) | xi in x], [bool2int(vi) | vi in v]);
+annotation warm_start_int(array[int] of var int: x, array[int] of int: v);
+annotation warm_start(array[int] of var int: x, array[int] of int: v) = warm_start_int(x, v);
+annotation warm_start_float(array[int] of var float: x, array[int] of float: v);
+annotation warm_start(array[int] of var float: x, array[int] of float: v) = warm_start_float(x, v);


### PR DESCRIPTION
This PR adds support for MiniZinc's `warm_start` annotation and exposes an assumption interface to MiniZinc.

As shown in the commit log, both these features have been implemented by Graeme Gange and rebased on the current develop branch by me.

As a small TODO, the `warm_start` functionality was implemented for integers, but MiniZinc uses the same annotation for other types. A small check should be added to see whether we actually received a version on integer variables.

As future work, we could also add support for `warm_start` on Boolean variables.