### PR TITLE
Fix the IntVarLL operations when domains have gaps

### DIFF
--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -167,6 +167,24 @@ public:
 	bool indomain(int64_t v) const {
 		return v >= min && v <= max && (!vals || vals[v]);
 	}
+	int64_t nextDomVal(int64_t v) const {
+		v++;
+		if (vals) {
+			while(!vals[v] && v <= max) {
+				v++;
+			}
+		}
+		return v;
+	}
+	int64_t prevDomVal(int64_t v) const {
+		v--;
+		if (vals) {
+			while(!vals[v] && v >= min) {
+				v--;
+			}
+		}
+		return v;
+	}
 
 	class iterator {
 		const IntVar* var;


### PR DESCRIPTION
This PR contains a fix for working with gaps in the domains of lazy variables. The "get literal" operations could create literals for values that were already removed from the domain. This would causes issues when setMin/setMax would then call their internal channel functions.