### PR TITLE
Temporarily fix for #10 by enforcing usage of the bounds propagator.

### DIFF
--- a/chuffed/core/propagator.h
+++ b/chuffed/core/propagator.h
@@ -28,6 +28,8 @@ Assumptions:
 #include <chuffed/core/sat.h>
 //#include "core/prop-group.h"
 
+// Propagation onsistency levels for, e.g., alldifferent: 
+//      default, value, bound, domain
 enum ConLevel { CL_DEF, CL_VAL, CL_BND, CL_DOM };
 
 class Propagator {

--- a/chuffed/globals/alldiff.cpp
+++ b/chuffed/globals/alldiff.cpp
@@ -865,15 +865,7 @@ void all_different(vec<IntVar*>& x, ConLevel cl) {
 		if (x[i]->getMax() > max) max = x[i]->getMax();
 	}
 	int range = max + 1 - min;
-	if (cl == CL_BND) {
-		vec<IntView<> > u;
-		for (int i = 0; i < x.size(); i++) u.push(IntView<>(x[i],1,-min));
-		if (min == 0) new AllDiffBounds<0>(u, range);
-		else          new AllDiffBounds<4>(u, range);
-		if (!so.alldiff_stage)
-			return;
-	}
-	else if (cl == CL_DOM) {
+	if (cl == CL_DOM) {
 		vec<IntView<> > u;
 		for (int i = 0; i < x.size(); i++) u.push(IntView<>(x[i],1,-min));
 		if (min == 0) new AllDiffDomain<0>(u, range);
@@ -881,6 +873,19 @@ void all_different(vec<IntVar*>& x, ConLevel cl) {
 		if (!so.alldiff_stage)
 			return;
 	}
+    else {
+        // NOTE that the bounds propagator will be posted temporarily, unless the
+        // consistency level is specified as "domain". There is an issue with the
+        // value propagator in the case "IntVarLL" integer variables are involved
+        // (see Issue #10). In the future, it needs to be decided how to 
+        // permamently fix this issue.
+		vec<IntView<> > u;
+		for (int i = 0; i < x.size(); i++) u.push(IntView<>(x[i],1,-min));
+		if (min == 0) new AllDiffBounds<0>(u, range);
+		else          new AllDiffBounds<4>(u, range);
+		if (!so.alldiff_stage && cl == CL_BND)
+			return;
+    }
 	vec<IntView<> > u;
 	for (int i = 0; i < x.size(); i++) u.push(IntView<>(x[i],1,-min));
 	if (min == 0) new AllDiffValue<0>(u, range);

--- a/chuffed/vars/int-var-ll.cpp
+++ b/chuffed/vars/int-var-ll.cpp
@@ -120,7 +120,11 @@ inline Lit IntVarLL::getLELit(int v) {
 }
 
 Lit IntVarLL::getLit(int64_t v, int t) {
-	assert(engine.decisionLevel() == 0);
+	// NOTE: Previous assertion that makes little sense. We should further
+	// investigate if the comparisons with min/max make sense at different
+	// decision levels.
+	// So far this assertion only seems to trigger with all_different (bounds)
+	// assert(engine.decisionLevel() == 0);
 	if (v < min) return toLit(1^(t&1));       // _, _, 1, 0
 	if (v > max) return toLit(t&1);           // _, _, 0, 1
 	switch (t) {


### PR DESCRIPTION
Enforced the usage of the bounds propagator unless the consistency level "domain" is specified. Thus, it will run even if the consistency level is "default" or "value".

NOTE that this is only a temporary fix.