### PR TITLE
Enforce that calls to getLit use LitRel instead of an int

### DIFF
--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -350,7 +350,8 @@ inline bool Engine::constrain() {
 	//  printf("%% opt_var min = %d, opt_var max = %d\n", opt_var->getMin(), opt_var->getMax());
 
 	if (so.lazy) {
-		Lit p = opt_type != 0 ? opt_var->getLit(best_sol + 1, 2) : opt_var->getLit(best_sol - 1, 3);
+		Lit p =
+				opt_type != 0 ? opt_var->getLit(best_sol + 1, LR_GE) : opt_var->getLit(best_sol - 1, LR_LE);
 		// GKG: Preserves existing assumptions, but assumes we've reserved
 		// space at the end for the objective bound.
 		if (assumptions.size() == 0) {

--- a/chuffed/examples/blackhole.cpp
+++ b/chuffed/examples/blackhole.cpp
@@ -90,7 +90,8 @@ public:
 						if ((j + 1) % 13 == k % 13) {
 							continue;
 						}
-						bool_rel(BoolView(y[i]->getLit(j, 1)), BRT_R_IMPL, BoolView(y[i + 1]->getLit(k, 0)));
+						bool_rel(BoolView(y[i]->getLit(j, LR_EQ)), BRT_R_IMPL,
+										 BoolView(y[i + 1]->getLit(k, LR_NE)));
 					}
 				}
 			}

--- a/chuffed/examples/grid_colouring.cpp
+++ b/chuffed/examples/grid_colouring.cpp
@@ -39,10 +39,10 @@ public:
 					for (int c2 = c1 + 1; c2 < m; c2++) {
 						for (int z = 1; z <= c; z++) {
 							vec<BoolView> a;
-							a.push(BoolView(x[r1][c1]->getLit(z, 0)));
-							a.push(BoolView(x[r2][c1]->getLit(z, 0)));
-							a.push(BoolView(x[r1][c2]->getLit(z, 0)));
-							a.push(BoolView(x[r2][c2]->getLit(z, 0)));
+							a.push(BoolView(x[r1][c1]->getLit(z, LR_NE)));
+							a.push(BoolView(x[r2][c1]->getLit(z, LR_NE)));
+							a.push(BoolView(x[r1][c2]->getLit(z, LR_NE)));
+							a.push(BoolView(x[r2][c2]->getLit(z, LR_NE)));
 							bool_clause(a);
 						}
 					}
@@ -58,7 +58,7 @@ public:
 				for (int z = 1; z <= c; z++) {
 					vec<BoolView> a;
 					for (int j = 0; j < m; j++) {
-						a.push(BoolView(x[i][j]->getLit(z, 1)));
+						a.push(BoolView(x[i][j]->getLit(z, LR_EQ)));
 					}
 					bool_linear(a, IRT_LE, ulimit);
 					bool_linear(a, IRT_GE, llimit);

--- a/chuffed/examples/nurse.cpp
+++ b/chuffed/examples/nurse.cpp
@@ -137,7 +137,7 @@ public:
 
 					vec<BoolView> rostered;
 					for (int k = 0; k < nNurses; k++) {
-						rostered.push(xs[(nNurses * j) + k]->getLit(i, 1));  // [[ nurse_shift = i ]]
+						rostered.push(xs[(nNurses * j) + k]->getLit(i, LR_EQ));  // [[ nurse_shift = i ]]
 					}
 					bool_linear_decomp(rostered, IRT_GE, req);
 #if 0

--- a/chuffed/examples/shift.cpp
+++ b/chuffed/examples/shift.cpp
@@ -192,7 +192,7 @@ public:
 			for (int act = 0; act < acts; act++) {
 				vec<BoolView> bv;
 				for (int ww = 0; ww < staff; ww++) {
-					bv.push(xv[ww][ss]->getLit(act, 1));
+					bv.push(xv[ww][ss]->getLit(act, LR_EQ));
 				}
 
 				bool_linear_decomp(bv, IRT_GE, demand[ss][act]);
@@ -208,7 +208,7 @@ public:
 			}
 
 			for (int ww = 0; ww < staff; ww++) {
-				rostered.push(xv[ww][ss]->getLit(acts - 1, 3));
+				rostered.push(xv[ww][ss]->getLit(acts - 1, LR_LE));
 			}
 		}
 
@@ -232,7 +232,7 @@ public:
       for(int ww = 0; ww < staff; ww++)
       {
         IntVar* sv = newIntVar(0,1);
-        bool2int(xv[ww][ss]->getLit(acts-1,3),sv);
+        bool2int(xv[ww][ss]->getLit(acts-1, LR_LE),sv);
         rostered_int.push(sv);
       }
     }

--- a/chuffed/examples/wreg_shift.cpp
+++ b/chuffed/examples/wreg_shift.cpp
@@ -122,7 +122,7 @@ public:
 			for (int act = 0; act < acts; act++) {
 				vec<BoolView> bv;
 				for (int ww = 0; ww < staff; ww++) {
-					bv.push(xv[ww][ss]->getLit(act, 1));
+					bv.push(xv[ww][ss]->getLit(act, LR_EQ));
 				}
 
 				bool_linear_decomp(bv, IRT_GE, demand[ss][act]);
@@ -151,7 +151,7 @@ public:
       for(int ww = 0; ww < staff; ww++)
       {
         IntVar* sv = newIntVar(0,1);
-        bool2int(xv[ww][ss]->getLit(acts-1,3),sv);
+        bool2int(xv[ww][ss]->getLit(acts-1, LR_LE),sv);
         rostered_int.push(sv);
       }
     }

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -209,22 +209,22 @@ void FlatZincSpace::newBoolVar(BoolVarSpec* vs) {
 			iv[vs->alias_var]->specialiseToEL();
 			switch (vs->alias_irt) {
 				case IRT_EQ:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, 1));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, LR_EQ));
 					break;
 				case IRT_NE:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, 0));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, LR_NE));
 					break;
 				case IRT_GE:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, 2));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, LR_GE));
 					break;
 				case IRT_GT:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val + 1, 2));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val + 1, LR_GE));
 					break;
 				case IRT_LE:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, 3));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val, LR_LE));
 					break;
 				case IRT_LT:
-					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val - 1, 3));
+					v = BoolView(iv[vs->alias_var]->getLit(vs->alias_val - 1, LR_LE));
 					break;
 				default:
 					NEVER;
@@ -410,7 +410,7 @@ void FlatZincSpace::parseSolveAnnWarmStart(AST::Node* elemAnn, BranchGroup* bran
 			switch (x->getType()) {
 				case INT_VAR_EL:
 				case INT_VAR_SL:
-					decs.push(x->getLit(k, 1));
+					decs.push(x->getLit(k, LR_EQ));
 					break;
 				default:
 					// Fallback. TODO: Do something nicer here.

--- a/chuffed/flatzinc/fzn-chuffed.cpp
+++ b/chuffed/flatzinc/fzn-chuffed.cpp
@@ -133,7 +133,8 @@ int main(int argc, char** argv) {
 #ifdef WIN32
 		SetConsoleCtrlHandler((PHANDLER_ROUTINE)SIGINT_handler, true);
 #else
-		std::signal(SIGINT, SIGINT_handler);
+		// TODO: Make signal handler use C linkage
+		std::signal(SIGINT, SIGINT_handler);  // NOLINT(bugprone-signal-handler)
 #endif
 
 		engine.set_assumptions(FlatZinc::s->assumptions);

--- a/chuffed/globals/EdExplFinder.cpp
+++ b/chuffed/globals/EdExplFinder.cpp
@@ -69,7 +69,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 #ifndef NDEBUG
 			std::cout << "x_" << i << " >= " << l << std::endl;
 #endif
-			litVector.push_back(seq1[i].getLit(l - 1, 3));
+			litVector.push_back(seq1[i].getLit(l - 1, LR_LE));
 		}
 
 		// create x_i <= u
@@ -78,7 +78,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 #ifndef NDEBUG
 			std::cout << "x_" << i << " <= " << u << std::endl;
 #endif
-			litVector.push_back(seq1[i].getLit(u + 1, 2));
+			litVector.push_back(seq1[i].getLit(u + 1, LR_GE));
 		}
 
 		// create remaining inequalities (x_i != c1)
@@ -88,7 +88,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 				std::cout << "x_" << i << " != " << c1 << std::endl;
 #endif
 				// we insert x_i = c1, as we have to actually negate the inequality
-				litVector.push_back(seq1[i].getLit(c1, 1));
+				litVector.push_back(seq1[i].getLit(c1, LR_EQ));
 			}
 		}
 	}
@@ -115,7 +115,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 			std::cout << "y_" << j << " >= " << l << std::endl;
 #endif
 			// we insert y_i <= l-1, as we have to actually negate the inequality
-			litVector.push_back(seq2[j].getLit(l - 1, 3));
+			litVector.push_back(seq2[j].getLit(l - 1, LR_LE));
 		}
 		// create y_i <= u
 		if (u < max_char && l <= u) {
@@ -123,7 +123,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 			std::cout << "y_" << j << " <= " << u << std::endl;
 #endif
 			// we insert y_i >= u+1, as we have to actually negate the inequality
-			litVector.push_back(seq2[j].getLit(u + 1, 2));
+			litVector.push_back(seq2[j].getLit(u + 1, LR_GE));
 		}
 
 		// create remaining inequalities (y_i != c1)
@@ -133,7 +133,7 @@ EdExplFinder::FindEdExplanation(int _max_char, const vec<int>* _insertion_cost,
 				std::cout << "y_" << j << " != " << c1 << std::endl;
 #endif
 				// we insert y_i = c1, as we have to actually negate the inequality
-				litVector.push_back(seq2[j].getLit(c1, 1));
+				litVector.push_back(seq2[j].getLit(c1, LR_EQ));
 			}
 		}
 	}

--- a/chuffed/globals/alldiff.cpp
+++ b/chuffed/globals/alldiff.cpp
@@ -32,7 +32,7 @@ public:
 			for (int i = 0; i < range; i++) {
 				vec<Lit> ps(sz);
 				for (int j = 0; j < sz; j++) {
-					ps[j] = x[j].getLit(i, 1);
+					ps[j] = x[j].getLit(i, LR_EQ);
 				}
 				sat.addClause(ps);
 			}
@@ -258,13 +258,13 @@ public:
 					}
 					// fprintf(stderr, "  in hall [%d, %d):\n", hall_min, hall_max);
 					r = Reason_new(2 + (hall_max - hall_min) * 2);
-					(*r)[1] = ~x[maxsorted[i]].getLit(hall_min, 2);
+					(*r)[1] = ~x[maxsorted[i]].getLit(hall_min, LR_GE);
 					int m = 2;
 					for (int k = w; bounds[k] > hall_min; --k) {
 						for (int l = bucket[k]; l >= 0; l = iv[l].next) {
 							// fprintf(stderr, "    var %d [%d, %d)\n", l, iv[l].min, iv[l].max);
-							(*r)[m++] = ~x[l].getLit(hall_min, 2);
-							(*r)[m++] = ~x[l].getLit(hall_max - 1, 3);
+							(*r)[m++] = ~x[l].getLit(hall_min, LR_GE);
+							(*r)[m++] = ~x[l].getLit(hall_max - 1, LR_LE);
 						}
 					}
 					assert(m == 2 + (hall_max - hall_min) * 2);
@@ -327,13 +327,13 @@ public:
 					}
 					// fprintf(stderr, "  in hall [%d, %d):\n", hall_min, hall_max);
 					r = Reason_new(2 + (hall_max - hall_min) * 2);
-					(*r)[1] = ~x[minsorted[i]].getLit(hall_max - 1, 3);
+					(*r)[1] = ~x[minsorted[i]].getLit(hall_max - 1, LR_LE);
 					int m = 2;
 					for (int k = w; bounds[k] < hall_max; ++k) {
 						for (int l = bucket[k]; l >= 0; l = iv[l].next) {
 							// fprintf(stderr, "    var %d [%d, %d)\n", l, iv[l].min, iv[l].max);
-							(*r)[m++] = ~x[l].getLit(hall_min, 2);
-							(*r)[m++] = ~x[l].getLit(hall_max - 1, 3);
+							(*r)[m++] = ~x[l].getLit(hall_min, LR_GE);
+							(*r)[m++] = ~x[l].getLit(hall_max - 1, LR_LE);
 						}
 					}
 					assert(m == 2 + (hall_max - hall_min) * 2);
@@ -560,13 +560,13 @@ public:
 				int k = 1;
 				for (int j = scc; j >= 0; j = var_nodes[j].next) {
 					if (j < sz) {
-						(*r)[k++] = ~x[j].getLit(min_val, 2);
+						(*r)[k++] = ~x[j].getLit(min_val, LR_GE);
 						for (int v = min_val + 1; v < max_val; ++v) {
 							if (!scoreboard[v]) {
-								(*r)[k++] = ~x[j].getLit(v, 0);
+								(*r)[k++] = ~x[j].getLit(v, LR_NE);
 							}
 						}
-						(*r)[k++] = ~x[j].getLit(max_val, 3);
+						(*r)[k++] = ~x[j].getLit(max_val, LR_LE);
 					}
 				}
 				assert(k == 1 + vars * (2 + (max_val + 1 - min_val) - vals));
@@ -792,13 +792,13 @@ public:
 					}
 					// fprintf(stderr, "  in hall [%d, %d):\n", hall_min, hall_max);
 					r = Reason_new(3 + (hall_max - hall_min) * 2);
-					(*r)[1] = ~x[maxsorted[i]].getLit(hall_min, 2);
+					(*r)[1] = ~x[maxsorted[i]].getLit(hall_min, LR_GE);
 					int m = 3;
 					for (int k = w; bounds[k] > hall_min; --k) {
 						for (int l = bucket[k]; l >= 0; l = iv[l].next) {
 							// fprintf(stderr, "    var %d [%d, %d)\n", l, iv[l].min, iv[l].max);
-							(*r)[m++] = ~x[l].getLit(hall_min, 2);
-							(*r)[m++] = ~x[l].getLit(hall_max - 1, 3);
+							(*r)[m++] = ~x[l].getLit(hall_min, LR_GE);
+							(*r)[m++] = ~x[l].getLit(hall_max - 1, LR_LE);
 						}
 					}
 					assert(m == 3 + (hall_max - hall_min) * 2);
@@ -819,7 +819,7 @@ public:
 					pathset(h, minrank, w, w);  // path compression
 				} else {
 					if (x[maxsorted[i]].getMax() < hall_max) {
-						(*r)[2] = x[maxsorted[i]].getLit(hall_max, 2);
+						(*r)[2] = x[maxsorted[i]].getLit(hall_max, LR_GE);
 						return b.setVal(false, r);
 					}
 				}
@@ -870,13 +870,13 @@ public:
 					}
 					// fprintf(stderr, "  in hall [%d, %d):\n", hall_min, hall_max);
 					r = Reason_new(3 + (hall_max - hall_min) * 2);
-					(*r)[1] = ~x[minsorted[i]].getLit(hall_max - 1, 3);
+					(*r)[1] = ~x[minsorted[i]].getLit(hall_max - 1, LR_LE);
 					int m = 3;
 					for (int k = w; bounds[k] < hall_max; ++k) {
 						for (int l = bucket[k]; l >= 0; l = iv[l].next) {
 							// fprintf(stderr, "    var %d [%d, %d)\n", l, iv[l].min, iv[l].max);
-							(*r)[m++] = ~x[l].getLit(hall_min, 2);
-							(*r)[m++] = ~x[l].getLit(hall_max - 1, 3);
+							(*r)[m++] = ~x[l].getLit(hall_min, LR_GE);
+							(*r)[m++] = ~x[l].getLit(hall_max - 1, LR_LE);
 						}
 					}
 					assert(m == 3 + (hall_max - hall_min) * 2);
@@ -897,7 +897,7 @@ public:
 					pathset(h, maxrank, w, w);  // path compression
 				} else {
 					if (x[maxsorted[i]].getMin() > hall_min + 1) {
-						(*r)[2] = x[maxsorted[i]].getLit(hall_min + 1, 3);
+						(*r)[2] = x[maxsorted[i]].getLit(hall_min + 1, LR_LE);
 						return static_cast<int>(b.setVal(false, r));
 					}
 				}
@@ -1086,8 +1086,8 @@ void inverse(vec<IntVar*>& x, vec<IntVar*>& y, int o1, int o2, ConLevel cl) {
 	}
 	for (int i = 0; i < x.size(); i++) {
 		for (int j = 0; j < y.size(); j++) {
-			sat.addClause(x[i]->getLit(o1 + j, 0), y[j]->getLit(o2 + i, 1));
-			sat.addClause(x[i]->getLit(o1 + j, 1), y[j]->getLit(o2 + i, 0));
+			sat.addClause(x[i]->getLit(o1 + j, LR_NE), y[j]->getLit(o2 + i, LR_EQ));
+			sat.addClause(x[i]->getLit(o1 + j, LR_EQ), y[j]->getLit(o2 + i, LR_NE));
 		}
 	}
 }

--- a/chuffed/globals/circuit.cpp
+++ b/chuffed/globals/circuit.cpp
@@ -190,7 +190,7 @@ public:
 				if (A[a] != a1 || B[b] != b1) {
 					assert(!x[A[a]].indomain(B[b]));
 					//  fprintf(stderr, "add %d not equal to %d\n", A[a], B[b]);
-					(*reason)[reasonIndex++] = ~x[A[a]].getLit(B[b], 0);
+					(*reason)[reasonIndex++] = ~x[A[a]].getLit(B[b], LR_NE);
 				} else {
 					found = true;
 				}
@@ -1061,12 +1061,12 @@ public:
 				for (int i = 0; i < chainLength; i++) {
 					int start = i * (2 + outsidebetween.size());
 					int varIndex = bestCycle[i];
-					if (i > 0) {                                            // leave out first literal
-						(*r)[start] = x[varIndex].getLit(smallestIn - 1, 3);  // x <= smallest-1
+					if (i > 0) {                                                // leave out first literal
+						(*r)[start] = x[varIndex].getLit(smallestIn - 1, LR_LE);  // x <= smallest-1
 					}
-					(*r)[start + 1] = x[varIndex].getLit(largestIn + 1, 2);  // x >= largest+1
+					(*r)[start + 1] = x[varIndex].getLit(largestIn + 1, LR_GE);  // x >= largest+1
 					for (int j = 0; j < outsidebetween.size(); j++) {
-						(*r)[start + 2 + j] = x[varIndex].getLit(outsidebetween[j], 1);  // x == k
+						(*r)[start + 2 + j] = x[varIndex].getLit(outsidebetween[j], LR_EQ);  // x == k
 					}
 				}
 

--- a/chuffed/globals/cumulative.cpp
+++ b/chuffed/globals/cumulative.cpp
@@ -35,8 +35,8 @@ void timed_cumulative(vec<IntVar*>& s, vec<int>& d, vec<int>& r, int b) {
 			if (!in[i]) {
 				continue;
 			}
-			BoolView b1(s[i]->getLit(t, 3));
-			BoolView b2(s[i]->getLit(t - d[i] + 1, 2));
+			BoolView b1(s[i]->getLit(t, LR_LE));
+			BoolView b2(s[i]->getLit(t - d[i] + 1, LR_GE));
 			BoolView b3 = newBoolVar();
 			IntVar* v = newIntVar(0, 1);
 			bool_rel(b1, BRT_AND, b2, b3);
@@ -707,13 +707,13 @@ public:
 
 	// Wrapper to get the negated literal -[[v <= val]] = [[v >= val + 1]]
 	static inline Lit getNegLeqLit(CUMU_INTVAR v, CUMU_INT val) {
-		// return v->getLit(val + 1, 2);
-		return (INT_VAR_LL == v->getType() ? v->getMaxLit() : v->getLit(val + 1, 2));
+		// return v->getLit(val + 1, LR_GE);
+		return (INT_VAR_LL == v->getType() ? v->getMaxLit() : v->getLit(val + 1, LR_GE));
 	}
 	// Wrapper to get the negated literal -[[v >= val]] = [[ v <= val - 1]]
 	static inline Lit getNegGeqLit(CUMU_INTVAR v, CUMU_INT val) {
-		// return v->getLit(val - 1, 3);
-		return (INT_VAR_LL == v->getType() ? v->getMinLit() : v->getLit(val - 1, 3));
+		// return v->getLit(val - 1, LR_LE);
+		return (INT_VAR_LL == v->getType() ? v->getMinLit() : v->getLit(val - 1, LR_LE));
 	}
 
 	// TTEF Propagator

--- a/chuffed/globals/cumulative.cpp
+++ b/chuffed/globals/cumulative.cpp
@@ -1698,7 +1698,7 @@ bool CumulativeProp::ttef_bounds_propagation_lb(int shift_in(const int, const in
 				// Check whether a new upper bound was found
 				if (lct_new < new_lct[j]) {
 					// Push possible update into the queue
-					update_queue.push(TTEFUpdate(j, lct_new, min_begin, end, 0));
+					update_queue.emplace(j, lct_new, min_begin, end, 0);
 					new_lct[j] = lct_new;
 					// int blah = max_limit() * (end - min_begin) - (min_en_avail + min_en_in);
 					// printf("%d: lct_new %d; dur_avail %d; en_req %d; [%d, %d)\n", j, lct_new, dur_avail,
@@ -1758,7 +1758,7 @@ bool CumulativeProp::ttef_bounds_propagation_lb(int shift_in(const int, const in
 				// - nfnl-rule TODO
 				if (start_new > new_est[j]) {
 					// Push possible update into the queue
-					update_queue.push(TTEFUpdate(j, start_new, begin, end, 1));
+					update_queue.emplace(j, start_new, begin, end, 1);
 					new_est[j] = start_new;
 					// printf("XXXXXX\n");
 				}
@@ -1857,7 +1857,7 @@ bool CumulativeProp::ttef_bounds_propagation_ub(int shift_in(const int, const in
 				// Check whether a new lower bound was found
 				if (est_new > new_est[j]) {
 					// Push possible update into the queue
-					update_queue.push(TTEFUpdate(j, est_new, begin, min_end, 1));
+					update_queue.emplace(j, est_new, begin, min_end, 1);
 					new_est[j] = est_new;
 					// int blah = max_limit() * (end - min_begin) - (min_en_avail + min_en_in);
 					// printf("%d: lct_new %d; dur_avail %d; en_req %d; [%d, %d)\n", j, lct_new, dur_avail,
@@ -1917,7 +1917,7 @@ bool CumulativeProp::ttef_bounds_propagation_ub(int shift_in(const int, const in
 				// - nfnl-rule TODO
 				if (end_new < new_lct[j]) {
 					// Push possible update into queue
-					update_queue.push(TTEFUpdate(j, end_new, begin, end, 0));
+					update_queue.emplace(j, end_new, begin, end, 0);
 					new_lct[j] = end_new;
 				}
 			}

--- a/chuffed/globals/cumulativeCalendar.cpp
+++ b/chuffed/globals/cumulativeCalendar.cpp
@@ -1070,13 +1070,13 @@ public:
 
 	// Wrapper to get the negated literal -[[v <= val]] = [[v >= val + 1]]
 	static inline Lit getNegLeqLit(CUMU_INTVAR v, CUMU_INT val) {
-		// return v->getLit(val + 1, 2);
-		return (INT_VAR_LL == v->getType() ? v->getMaxLit() : v->getLit(val + 1, 2));
+		// return v->getLit(val + 1, LR_GE);
+		return (INT_VAR_LL == v->getType() ? v->getMaxLit() : v->getLit(val + 1, LR_GE));
 	}
 	// Wrapper to get the negated literal -[[v >= val]] = [[ v <= val - 1]]
 	static inline Lit getNegGeqLit(CUMU_INTVAR v, CUMU_INT val) {
-		// return v->getLit(val - 1, 3);
-		return (INT_VAR_LL == v->getType() ? v->getMinLit() : v->getLit(val - 1, 3));
+		// return v->getLit(val - 1, LR_LE);
+		return (INT_VAR_LL == v->getType() ? v->getMinLit() : v->getLit(val - 1, LR_LE));
 	}
 };
 

--- a/chuffed/globals/cumulativeCalendar.cpp
+++ b/chuffed/globals/cumulativeCalendar.cpp
@@ -2022,7 +2022,7 @@ bool CumulativeCalProp::ttef_bounds_propagation_lb(int shift_in,
 				// - nfnl-rule TODO
 				if (start_new > new_est[j]) {
 					// Push possible update into the queue
-					update_queue.push(TTEFUpdate(j, start_new, begin, end, 1));
+					update_queue.emplace(j, start_new, begin, end, 1);
 					new_est[j] = start_new;
 				}
 			}
@@ -2244,7 +2244,7 @@ bool CumulativeCalProp::ttef_bounds_propagation_ub(int shift_in,
 				// - nfnl-rule TODO
 				if (end_new < new_lct[j]) {
 					// Push possible update into queue
-					update_queue.push(TTEFUpdate(j, end_new, begin, end, 0));
+					update_queue.emplace(j, end_new, begin, end, 0);
 					new_lct[j] = end_new;
 				}
 			}
@@ -2316,7 +2316,7 @@ void CumulativeCalProp::tteef_bounds_propagation_lb(const int begin, const int e
 		// Check whether a new lower bound was found
 		if (est_new > new_est[j]) {
 			// Push possible update into the queue
-			update_queue.push(TTEFUpdate(j, est_new, begin, end, 1));
+			update_queue.emplace(j, est_new, begin, end, 1);
 			new_est[j] = est_new;
 		}
 	}
@@ -2356,7 +2356,7 @@ void CumulativeCalProp::tteef_bounds_propagation_ub(const int begin, const int e
 		// Check whether a new upper bound was found
 		if (lct_new < new_lct[j]) {
 			// Push possible update into the queue
-			update_queue.push(TTEFUpdate(j, lct_new, begin, end, 0));
+			update_queue.emplace(j, lct_new, begin, end, 0);
 			new_lct[j] = lct_new;
 		}
 	}

--- a/chuffed/globals/disjunctive.cpp
+++ b/chuffed/globals/disjunctive.cpp
@@ -126,7 +126,7 @@ public:
 					BoolView& p = pred[i][pi.var];
 					if (p.isTrue() && est(i) >= pi.est) {
 						ps.push(p.getValLit());
-						ps.push(x[i]->getLit(pi.est-1, 3));
+						ps.push(x[i]->getLit(pi.est-1, LR_LE));
 					}
 				}
 		*/
@@ -456,11 +456,11 @@ public:
 		}
 
 		/*
-				ps.push(x[pi.var]->getLit(set_est, 2));
+				ps.push(x[pi.var]->getLit(set_est, LR_GE));
 				for (int i = 0; i < x.size(); i++) {
 					if (!in[i]) continue;
-					ps.push(x[i]->getLit(set_est, 2));
-					ps.push(x[i]->getLit(set_let - dur[i], 3));
+					ps.push(x[i]->getLit(set_est, LR_GE));
+					ps.push(x[i]->getLit(set_let - dur[i], LR_LE));
 				}
 		*/
 
@@ -573,11 +573,11 @@ public:
 		}
 
 		/*
-				ps.push(x[pi.var]->getLit(set_est, 2));
+				ps.push(x[pi.var]->getLit(set_est, LR_GE));
 				for (int i = 0; i < x.size(); i++) {
 					if (!in[i]) continue;
-					ps.push(x[i]->getLit(set_est, 2));
-					ps.push(x[i]->getLit(pi.let - dur[i], 3));
+					ps.push(x[i]->getLit(set_est, LR_GE));
+					ps.push(x[i]->getLit(pi.let - dur[i], LR_LE));
 				}
 		*/
 

--- a/chuffed/globals/dtree.cpp
+++ b/chuffed/globals/dtree.cpp
@@ -291,7 +291,7 @@ DTreeParenthoodPropagator::DTreeParenthoodPropagator(int _r, vec<BoolView>& _vs,
 	for (int i = 0; i < nbNodes(); i++) {
 		parents[i]->specialiseToEL();
 		for (int val = 0; val < nbNodes(); val++) {
-			equalities.push(parents[i]->getLit(val, 1));  // parents[i] == val
+			equalities.push(parents[i]->getLit(val, LR_EQ));  // parents[i] == val
 			equalities.last().attach(this, count, EVENT_LU);
 			event2parrel[count] = std::make_pair(i, val);
 			count++;
@@ -430,7 +430,7 @@ bool DTreeParenthoodPropagator::propagateNewParent(int e) {
 			vec<Lit> ps;
 			ps.push();
 			// Because I am my own parent, every edge is false (except self loop)
-			ps.push(parents[chi]->getLit(par, 1));
+			ps.push(parents[chi]->getLit(par, LR_EQ));
 			r = Reason_new(ps);
 		}
 		for (unsigned int i = 0; i < in[chi].size(); i++) {
@@ -445,7 +445,7 @@ bool DTreeParenthoodPropagator::propagateNewParent(int e) {
 					vec<Lit> ps;
 					// The fact that the parent of chi is not the
 					// tail of edge, when in the graph 'edge' exists
-					ps.push(parents[chi]->getLit(getTail(edge), 0));
+					ps.push(parents[chi]->getLit(getTail(edge), LR_NE));
 					ps.push(getEdgeVar(edge).getValLit());
 					Clause* expl = Clause_new(ps);
 					expl->temp_expl = 1;
@@ -464,15 +464,15 @@ bool DTreeParenthoodPropagator::propagateNewParent(int e) {
 		if (so.lazy) {
 			vec<Lit> ps;
 			ps.push();
-			ps.push(parents[chi]->getLit(par, 1));
+			ps.push(parents[chi]->getLit(par, LR_EQ));
 			r = Reason_new(ps);
 		}
 		getEdgeVar(e).setVal(true, r);
 	} else if (getEdgeVar(e).isFalse()) {
 		if (so.lazy) {
 			vec<Lit> ps;
-			ps.push(getEdgeVar(e).getValLit());     // par-->chi is out
-			ps.push(parents[chi]->getLit(par, 0));  // not(parents[chi] != par)
+			ps.push(getEdgeVar(e).getValLit());         // par-->chi is out
+			ps.push(parents[chi]->getLit(par, LR_NE));  // not(parents[chi] != par)
 			Clause* expl = Clause_new(ps);
 			expl->temp_expl = 1;
 			sat.rtrail.last().push(expl);
@@ -493,15 +493,15 @@ bool DTreeParenthoodPropagator::propagateRemParent(int e) {
 		if (so.lazy) {
 			vec<Lit> ps;
 			ps.push();
-			ps.push(parents[chi]->getLit(par, 0));
+			ps.push(parents[chi]->getLit(par, LR_NE));
 			r = Reason_new(ps);
 		}
 		getEdgeVar(e).setVal(false, r);
 	} else if (getEdgeVar(e).isTrue()) {
 		if (so.lazy) {
 			vec<Lit> ps;
-			ps.push(getEdgeVar(e).getValLit());     // par-->chi is in
-			ps.push(parents[chi]->getLit(par, 1));  // not(parents[chi] == par)
+			ps.push(getEdgeVar(e).getValLit());         // par-->chi is in
+			ps.push(parents[chi]->getLit(par, LR_EQ));  // not(parents[chi] == par)
 			Clause* expl = Clause_new(ps);
 			expl->temp_expl = 1;
 			sat.rtrail.last().push(expl);
@@ -667,7 +667,7 @@ void DTreeParenthoodPropagator::clearPropState() {
 //     for (int i = 0; i < nbNodes(); i++) {
 //         parents[i]->specialiseToEL();
 //         for (int val = 0; val < nbNodes(); val++) {
-//             equalities.push(parents[i]->getLit(val,1)); //parents[i] == val
+//             equalities.push(parents[i]->getLit(val, LR_EQ)); //parents[i] == val
 //             equalities.last().attach(this, count, EVENT_LU);
 //             event2parrel[count] = std::make_pair<int,int>(i,val);
 //             count++;
@@ -746,7 +746,7 @@ void DTreeParenthoodPropagator::clearPropState() {
 //         if (so.lazy) {
 //             vec<Lit> psfail;
 //             psfail.push(getEdgeVar(e).getValLit());
-//             //psfail.push(parents[getTail(e)]->getLit(getHead(e),1));
+//             //psfail.push(parents[getTail(e)]->getLit(getHead(e), LR_EQ));
 //             psfail.push(equalities[getTail(e)*nbNodes()+getHead(e)].getValLit()); //not(parent of
 //             tl is hd) Clause *expl = Clause_new(psfail); expl->temp_expl = 1;
 //             sat.rtrail.last().push(expl);
@@ -793,7 +793,7 @@ void DTreeParenthoodPropagator::clearPropState() {
 //     if (!getEdgeVar(e).isFixed()) {
 //         if (so.lazy) {
 //             vec<Lit> ps; ps.push();
-//             //ps.push(parents[getTail(e)]->getLit(getHead(e),1));
+//             //ps.push(parents[getTail(e)]->getLit(getHead(e), LR_EQ));
 //             ps.push(equalities[getTail(e)*nbNodes()+getHead(e)].getValLit());
 //             r = Reason_new(ps);
 //         }

--- a/chuffed/globals/edit_distance.cpp
+++ b/chuffed/globals/edit_distance.cpp
@@ -357,13 +357,13 @@ private:
 		// insert all clauses for each variable in sequence 1
 		for (int i = 0; i < seqSize; i++) {
 			// x != val
-			(*r)[offset + i] = seq1[i].getLit(seq1[i].getVal(), 0);
+			(*r)[offset + i] = seq1[i].getLit(seq1[i].getVal(), LR_NE);
 		}
 		offset += seqSize;
 		// insert all clauses for each variable in sequence 2
 		for (int i = 0; i < seqSize; i++) {
 			// x != val
-			(*r)[offset + i] = seq2[i].getLit(seq2[i].getVal(), 0);
+			(*r)[offset + i] = seq2[i].getLit(seq2[i].getVal(), LR_NE);
 		}
 
 		return r;
@@ -442,15 +442,15 @@ void edit_distance(int max_char, vec<int>& insertion_cost, vec<int>& deletion_co
 	for (int i = 0; i < seq1.size() - 1; i++) {
 		// x_i >= 1 v x_i+1 <= 0
 		vec<Lit> cl;
-		cl.push(seq1[i]->getLit(1, 2));
-		cl.push(seq1[i + 1]->getLit(0, 3));
+		cl.push(seq1[i]->getLit(1, LR_GE));
+		cl.push(seq1[i + 1]->getLit(0, LR_LE));
 		sat.addClause(cl);
 	}
 	for (int i = 0; i < seq2.size() - 1; i++) {
 		// x_i >= 1 v x_i+1 <= 0
 		vec<Lit> cl;
-		cl.push(seq2[i]->getLit(1, 2));
-		cl.push(seq2[i + 1]->getLit(0, 3));
+		cl.push(seq2[i]->getLit(1, LR_GE));
+		cl.push(seq2[i + 1]->getLit(0, LR_LE));
 		sat.addClause(cl);
 	}
 

--- a/chuffed/globals/linear-bool-decomp.cpp
+++ b/chuffed/globals/linear-bool-decomp.cpp
@@ -90,7 +90,7 @@ void bool_linear_decomp(vec<BoolView>& x, IntRelType t, IntVar* kv) {
 
 	vec<Lit> terminals;
 	for (int ii = 0; ii <= k; ii++) {
-		terminals.push(kv->getLit(ii, 2));  // kv >= ii
+		terminals.push(kv->getLit(ii, LR_GE));  // kv >= ii
 	}
 
 	vec<Lit> xv;

--- a/chuffed/globals/minimum.cpp
+++ b/chuffed/globals/minimum.cpp
@@ -78,7 +78,7 @@ public:
 					for (int i = 0; i < sz; i++) {
 						(*r)[i + 1] = x[i].getFMinLit(m);
 					}
-					//					for (int i = 0; i < sz; i++) (*r)[i+1] = x[i].getLit(m-1, 3);
+					//					for (int i = 0; i < sz; i++) (*r)[i+1] = x[i].getLit(m-1, LR_LE);
 				}
 				if (!y.setMin(m, r)) {
 					return false;

--- a/chuffed/globals/subcircuit.cpp
+++ b/chuffed/globals/subcircuit.cpp
@@ -186,7 +186,7 @@ public:
 							v = x[v].getVal();
 						}
 
-						(*r)[chainLength] = ~x[evidenceVar].getLit(evidenceVar, 0);
+						(*r)[chainLength] = ~x[evidenceVar].getLit(evidenceVar, LR_NE);
 					} else {
 						// find the vars in the start of the chain and those not in the chain
 						vec<int> inStartChain;
@@ -208,7 +208,7 @@ public:
 						r = Reason_new(explSize);
 
 						explainAcantreachB(r, 1, inStartChain, outside);
-						(*r)[explSize - 1] = ~x[evidenceVar].getLit(evidenceVar, 0);
+						(*r)[explSize - 1] = ~x[evidenceVar].getLit(evidenceVar, LR_NE);
 					}
 				}
 
@@ -242,7 +242,7 @@ public:
 				}
 			}
 			assert(found);
-			Lit result = ~x[chosen].getLit(chosen, 0);
+			Lit result = ~x[chosen].getLit(chosen, LR_NE);
 			assert(result != lit_True);
 			return result;
 		}
@@ -263,7 +263,7 @@ public:
 				if (A[a] != a1 || B[b] != b1) {
 					assert(!x[A[a]].indomain(B[b]));
 					// fprintf(stderr, "add %d not equal to %d\n", A[a], B[b]);
-					(*reason)[reasonIndex++] = ~x[A[a]].getLit(B[b], 0);
+					(*reason)[reasonIndex++] = ~x[A[a]].getLit(B[b], LR_NE);
 				}
 			}
 		}
@@ -894,7 +894,7 @@ public:
 						// the first literal is an evidence literal from inside the circuit
 						// choose the one from the highest level?
 						int chosenVar = chooseEvidenceVar(inCycle, so.checkevidence);
-						(*r)[1] = x[chosenVar].getLit(chosenVar, 1);  // xi == i (is false)
+						(*r)[1] = x[chosenVar].getLit(chosenVar, LR_EQ);  // xi == i (is false)
 
 						if (so.checkexpl == 2) {  // inside can't reach out
 							doOutsideIn = false;
@@ -972,7 +972,7 @@ public:
 					 for(int i = 0; i < options.size(); i++)
 					 {
 								int v = options[i];
-								Lit p = x[v].getLit(v,0);
+								Lit p = x[v].getLit(v, LR_NE);
 								int satvar = var(p);
 							if(sat.activity[satvar] > highestAct)
 							{
@@ -985,12 +985,12 @@ public:
 			 else if(selectionMethod == 4)
 			 {
 					 // lowest activity
-					 double lowestAct = sat.activity[var(x[options[0]].getLit(options[0],0))];
+					 double lowestAct = sat.activity[var(x[options[0]].getLit(options[0], LR_NE))];
 					 int bestVar = options[0];
 					 for(int i = 1; i < options.size(); i++)
 					 {
 								int v = options[i];
-								Lit p = x[v].getLit(v,0);
+								Lit p = x[v].getLit(v, LR_NE);
 								int satvar = var(p);
 							if(sat.activity[satvar] < lowestAct)
 							{
@@ -1004,20 +1004,20 @@ public:
 			// highest level
 			// XXX [AS] Replaced 'sat.level' by 'sat.trailpos', because it was replaced in rev. 441
 			// Maybe it shoud be replaced by sat.getLevel(.)?
-			int highestLevel = sat.trailpos[var(x[options[0]].getLit(options[0], 1))];
-			// int highestLevel = sat.getLevel(var(x[options[0]].getLit(options[0],1)));
+			int highestLevel = sat.trailpos[var(x[options[0]].getLit(options[0], LR_EQ))];
+			// int highestLevel = sat.getLevel(var(x[options[0]].getLit(options[0], LR_EQ)));
 			int bestVar = options[0];
 			for (int i = 0; i < options.size(); i++) {
 				// XXX [AS] Replaced 'sat.level' by 'sat.trailpos', because it was replaced in rev. 441
 				// Maybe it shoud be replaced by sat.getLevel(.)?
-				if (sat.trailpos[var(x[options[0]].getLit(options[0], 1))] !=
-						sat.trailpos[var(x[options[0]].getLit(options[0], 0))]) {
-					// if(sat.getLevel(var(x[options[0]].getLit(options[0],1))) !=
-					// sat.getLevel(var(x[options[0]].getLit(options[0],0))))
+				if (sat.trailpos[var(x[options[0]].getLit(options[0], LR_EQ))] !=
+						sat.trailpos[var(x[options[0]].getLit(options[0], LR_NE))]) {
+					// if(sat.getLevel(var(x[options[0]].getLit(options[0], LR_EQ))) !=
+					// sat.getLevel(var(x[options[0]].getLit(options[0], LR_NE))))
 					fprintf(stderr, "not same\n");
 				}
 				int v = options[i];
-				Lit p = x[v].getLit(v, 1);
+				Lit p = x[v].getLit(v, LR_EQ);
 				int satvar = var(p);
 				// XXX [AS] Replaced 'sat.level' by 'sat.trailpos', because it was replaced in rev. 441
 				// Maybe it shoud be replaced by sat.getLevel(.)?
@@ -1037,12 +1037,12 @@ public:
 			// lowest level
 			// XXX [AS] Replaced 'sat.level' by 'sat.trailpos', because it was replaced in rev. 441
 			// Maybe it shoud be replaced by sat.getLevel(.)?
-			int lowestLevel = sat.trailpos[var(x[options[0]].getLit(options[0], 1))];
-			// int lowestLevel = sat.getLevel(var(x[options[0]].getLit(options[0],1)));
+			int lowestLevel = sat.trailpos[var(x[options[0]].getLit(options[0], LR_EQ))];
+			// int lowestLevel = sat.getLevel(var(x[options[0]].getLit(options[0], LR_EQ)));
 			int bestVar = options[0];
 			for (int i = 0; i < options.size(); i++) {
 				int v = options[i];
-				Lit p = x[v].getLit(v, 1);
+				Lit p = x[v].getLit(v, LR_EQ);
 				int satvar = var(p);
 				// XXX [AS] Replaced 'sat.level' by 'sat.trailpos', because it was replaced in rev. 441
 				// Maybe it shoud be replaced by sat.getLevel(.)?

--- a/chuffed/globals/sym-break.cpp
+++ b/chuffed/globals/sym-break.cpp
@@ -44,8 +44,8 @@ void val_sym_break(vec<IntVar*>& x, int l, int u) {
 	}
 	for (int i = l; i <= u; i++) {
 		for (int j = 0; j < x.size(); j++) {
-			bool_rel(y[i - l]->getLit(j, 1), BRT_R_IMPL, x[j]->getLit(i, 1));
-			bool_rel(x[j]->getLit(i, 1), BRT_R_IMPL, y[i - l]->getLit(j, 3));
+			bool_rel(y[i - l]->getLit(j, LR_EQ), BRT_R_IMPL, x[j]->getLit(i, LR_EQ));
+			bool_rel(x[j]->getLit(i, LR_EQ), BRT_R_IMPL, y[i - l]->getLit(j, LR_LE));
 		}
 	}
 	for (int i = 0; i < u - l; i++) {

--- a/chuffed/globals/table.cpp
+++ b/chuffed/globals/table.cpp
@@ -19,7 +19,7 @@ void table_GAC(vec<IntVar*>& x, vec<vec<int> >& t) {
 		for (int i = 0; i < t.size(); i++) {
 			sat.newVar();
 			for (int j = 0; j < x.size(); j++) {
-				sat.addClause(toLit(base_lit + 2 * i), x[j]->getLit(t[i][j], 1));
+				sat.addClause(toLit(base_lit + 2 * i), x[j]->getLit(t[i][j], LR_EQ));
 			}
 		}
 	}
@@ -42,7 +42,7 @@ void table_GAC(vec<IntVar*>& x, vec<vec<int> >& t) {
 				continue;
 			}
 			if (x.size() == 2) {
-				sup[k].push(x[1 - w]->getLit(t[i][1 - w], 1));
+				sup[k].push(x[1 - w]->getLit(t[i][1 - w], LR_EQ));
 			} else {
 				sup[k].push(toLit(base_lit + 2 * i + 1));
 			}
@@ -54,7 +54,7 @@ void table_GAC(vec<IntVar*>& x, vec<vec<int> >& t) {
 			}
 			assert(sup[i].size() >= 1);
 			assert(i + sup_off <= x[w]->getMax());
-			sup[i].push(x[w]->getLit(i + sup_off, 0));
+			sup[i].push(x[w]->getLit(i + sup_off, LR_NE));
 			Lit p = sup[i][0];
 			sup[i][0] = sup[i].last();
 			sup[i].last() = p;

--- a/chuffed/globals/tree.cpp
+++ b/chuffed/globals/tree.cpp
@@ -1119,8 +1119,8 @@ public:
 				}
 				// n is mand
 				if (!visited[n]) {
-					leaving_cc[last_t].push_back(vector<pair<int, int> >());
-					border_cc[last_t].push_back(vector<int>());
+					leaving_cc[last_t].emplace_back();
+					border_cc[last_t].emplace_back();
 					int last_cc = leaving_cc[last_t].size() - 1;
 					std::queue<int> q;
 					q.push(n);
@@ -1131,7 +1131,7 @@ public:
 						vector<int> adj = p->getAdjacentEdges(c);
 						for (int e : adj) {
 							if (!p->getEdgeVar(e).isFixed()) {
-								leaving_cc[last_t][last_cc].push_back(make_pair(e, p->getOtherEndnode(e, c)));
+								leaving_cc[last_t][last_cc].emplace_back(e, p->getOtherEndnode(e, c));
 								if (border_cc[last_t][last_cc].empty() || border_cc[last_t][last_cc].back() != c) {
 									border_cc[last_t][last_cc].push_back(c);
 								}

--- a/chuffed/ldsb/ldsb.cpp
+++ b/chuffed/ldsb/ldsb.cpp
@@ -392,13 +392,13 @@ public:
 					v /= 2;
 					// lit means <= v, and is false
 					for (int j = min; j <= v; j++) {
-						ps.push(var->getLit(j, 1));
+						ps.push(var->getLit(j, LR_EQ));
 					}
 				} else {
 					v /= 2;
 					// lit means >= v, and is false
 					for (int j = v; j <= max; j++) {
-						ps.push(var->getLit(j, 1));
+						ps.push(var->getLit(j, LR_EQ));
 					}
 				}
 				continue;

--- a/chuffed/mdd/mdd_prop.cpp
+++ b/chuffed/mdd/mdd_prop.cpp
@@ -149,8 +149,8 @@ MDDProp<U>::MDDProp(MDDTemplate* _templ, vec<IntView<U> >& _intvars, const MDDOp
 	for (int i = 0; i < intvars.size(); i++) {
 		for (int j = 0; j < _templ->_doms[i]; j++) {
 			//         assert( intvars[i].getMin() <= j && j <= intvars[i].getMax() );
-			boolvars.push(intvars[i].getLit(j, 1));  // v[i] \eq j
-																							 //         attach(boolvars.last(), EVENT_U);
+			boolvars.push(intvars[i].getLit(j, LR_EQ));  // v[i] \eq j
+																									 //         attach(boolvars.last(), EVENT_U);
 			boolvars.last().attach(this, boolvars.size() - 1, EVENT_U);
 
 			activity.push(0);
@@ -1008,7 +1008,7 @@ bool MDDProp<U>::fullProp() {
 			for (int i = 0; i < expl.size(); i++) {
 				// Fixme: adjust to handle WEAKNOGOOD
 #ifndef WEAKNOGOOD
-				(*r)[i] = intvars[val_entries[expl[i]].var].getLit(val_entries[expl[i]].val, 1);
+				(*r)[i] = intvars[val_entries[expl[i]].var].getLit(val_entries[expl[i]].val, LR_EQ);
 #else
 				int eval = expl[i] < 0 ? -1 * (expl[i] + 2) : expl[i];
 				(*r)[i] = intvars[val_entries[eval].var].getLit(val_entries[eval].val, expl[i] < 0 ? 0 : 1);
@@ -1037,7 +1037,7 @@ bool MDDProp<U>::fullProp() {
 
                for( int k = 1; k < expl.size(); k++ )
                {
-                  (*r)[k] = intvars[val_entries[expl[k]].var].getLit(val_entries[expl[k]].val,1);
+                  (*r)[k] = intvars[val_entries[expl[k]].var].getLit(val_entries[expl[k]].val, LR_EQ);
                }
 #endif
 			}
@@ -1258,7 +1258,7 @@ bool MDDProp<U>::propagate() {
 				// Fixme: adjust to handle WEAKNOGOOD
 				//               (*r)[i] = boolvars[expl[i]].getLit(0);
 				(*r)[i] = expl[i] >= 0
-											? intvars[val_entries[expl[i]].var].getLit(val_entries[expl[i]].val, 1)
+											? intvars[val_entries[expl[i]].var].getLit(val_entries[expl[i]].val, LR_EQ)
 											: intvars[val_entries[-1 * expl[i] - 2].var].getLit(
 														val_entries[-1 * expl[i] - 2].val, 0);
 			}
@@ -1478,8 +1478,8 @@ bool MDDProp<U>::propagate() {
                {
 //                  (*r)[k] = boolvars[expl[k]].getLit(0);
                   (*r)[k] = expl[k] >= 0
-                       ? intvars[val_entries[expl[k]].var].getLit(val_entries[expl[k]].val,1)
-                       : intvars[val_entries[-1*expl[k] - 2].var].getLit(val_entries[-1*expl[k] - 2].val,0);
+                       ? intvars[val_entries[expl[k]].var].getLit(val_entries[expl[k]].val, LR_EQ)
+                       : intvars[val_entries[-1*expl[k] - 2].var].getLit(val_entries[-1*expl[k] - 2].val, LR_NE);
                }
 #endif
 			}
@@ -1819,7 +1819,7 @@ void mdd_decomp_dc(vec<IntVar*> xs, MDDTable& t, MDDNodeInt root) {
 		sat.addClause(nodevars[e.end], ~edgevars[ei]);
 
 		// ~val -> ~e
-		Lit vlit = xs[vals[e.val].var]->getLit(vals[e.val].val, 1);
+		Lit vlit = xs[vals[e.val].var]->getLit(vals[e.val].val, LR_EQ);
 		sat.addClause(vlit, ~edgevars[ei]);
 
 		// ~parent -> ~e
@@ -1868,7 +1868,7 @@ void mdd_decomp_dc(vec<IntVar*> xs, MDDTable& t, MDDNodeInt root) {
 	// Val constraints
 	for (int vi = 0; vi < vals.size(); vi++) {
 		val_entry& vinfo(vals[vi]);
-		Lit vlit = xs[vinfo.var]->getLit(vinfo.val, 1);
+		Lit vlit = xs[vinfo.var]->getLit(vinfo.val, LR_EQ);
 		if (vinfo.count > 0) {
 			vec<Lit> cl;
 			cl.push(~vlit);

--- a/chuffed/mdd/mdd_prop.h
+++ b/chuffed/mdd/mdd_prop.h
@@ -134,7 +134,7 @@ public:
 
 	inline Lit get_val_lit(int v) {
 #ifndef WEAKNOGOOD
-		return intvars[val_entries[v].var].getLit(val_entries[v].val, 1);
+		return intvars[val_entries[v].var].getLit(val_entries[v].val, LR_EQ);
 #else
 		int eval = v < 0 ? -1 * (v + 2) : v;
 		return intvars[val_entries[eval].var].getLit(val_entries[eval].val, v < 0 ? 0 : 1);

--- a/chuffed/mdd/wmdd_prop.cpp
+++ b/chuffed/mdd/wmdd_prop.cpp
@@ -79,7 +79,7 @@ WMDDProp::WMDDProp(vec<IntView<> >& _vs, IntView<> _c, vec<int>& _levels, vec<Ed
 		varinfo.push(info);
 
 		for (int j = min; j <= max; j++) {
-			boolvars.push(intvars[i].getLit(j, 1));  // v[i] \eq j
+			boolvars.push(intvars[i].getLit(j, LR_EQ));  // v[i] \eq j
 			boolvars.last().attach(this, boolvars.size() - 1, EVENT_U);
 			val_edges.push();
 		}
@@ -1308,17 +1308,17 @@ void WMDDProp::collect_lits(vec<Lit>& expln) {
 		Val& vinfo(vals[vv]);
 #ifndef WEAKNOGOOD
 		if (vinfo.status != 0U) {
-			expln.push(intvars[vinfo.var].getLit(vinfo.val, 1));
+			expln.push(intvars[vinfo.var].getLit(vinfo.val, LR_EQ));
 			vinfo.status = 0;
 		}
 #else
 		switch (vinfo.status) {
 			case VAL_LOCKED:
 				// vinfo.status is set to 2 if the literal is negated
-				expln.push(intvars[vinfo.var].getLit(vinfo.val, 1));
+				expln.push(intvars[vinfo.var].getLit(vinfo.val, LR_EQ));
 				break;
 			case VAL_WEAK:
-				expln.push(intvars[vinfo.var].getLit(vinfo.val, 0));
+				expln.push(intvars[vinfo.var].getLit(vinfo.val, LR_NE));
 				break;
 			default:
 				break;
@@ -1335,7 +1335,7 @@ Clause* WMDDProp::explainConflict() {
 	int maxC = mark_frontier(-1, -1);
 #if 1
 	if (maxC < INT_MAX) {
-		expln.push(cost.getLit(maxC, 2));
+		expln.push(cost.getLit(maxC, LR_GE));
 		maxC--;  // Force the assignment to be infeasible.
 	}
 #else
@@ -1352,7 +1352,7 @@ Clause* WMDDProp::explainConflict() {
 
 	int maxC = late_minC(-1, -1);
 	if (maxC < INT_MAX) {
-		expln.push(cost.getLit(maxC, 2));
+		expln.push(cost.getLit(maxC, LR_GE));
 	}
 	collect_lits(expln);
 #endif
@@ -1414,7 +1414,7 @@ Clause* WMDDProp::explain(Lit p, int inf) {
 		int maxC = mark_frontier(var, val);
 #if 1
 		if (maxC < INT_MAX) {
-			expln.push(cost.getLit(maxC, 2));
+			expln.push(cost.getLit(maxC, LR_GE));
 			maxC--;
 		}
 #else
@@ -1432,7 +1432,7 @@ Clause* WMDDProp::explain(Lit p, int inf) {
 
 		int maxC = late_minC(var, val);
 		if (maxC < INT_MAX) {
-			expln.push(cost.getLit(maxC, 2));
+			expln.push(cost.getLit(maxC, LR_GE));
 		}
 		collect_lits(expln);
 #endif
@@ -1633,7 +1633,7 @@ void WMDDProp::incExplainUp(vec<int>& upQ, vec<Lit>& expln) {
 	for (int vi = 0; vi < explVals.size(); vi++) {
 		int vv = explVals[vi];
 		Val& vinfo(vals[vv]);
-		expln.push(intvars[vinfo.var].getLit(vinfo.val, 1));
+		expln.push(intvars[vinfo.var].getLit(vinfo.val, LR_EQ));
 
 		vinfo.status = 0;
 	}
@@ -1721,7 +1721,7 @@ void WMDDProp::incExplainDown(vec<int>& downQ, vec<Lit>& expln) {
 	for (int vi = 0; vi < explVals.size(); vi++) {
 		int vv = explVals[vi];
 		Val& vinfo(vals[vv]);
-		expln.push(intvars[vinfo.var].getLit(vinfo.val, 1));
+		expln.push(intvars[vinfo.var].getLit(vinfo.val, LR_EQ));
 
 		vinfo.status = 0;
 	}

--- a/chuffed/primitives/arithmetic.cpp
+++ b/chuffed/primitives/arithmetic.cpp
@@ -31,7 +31,7 @@ public:
 			int64_t t = (-l > u ? -l : u);
 			setDom(y, setMax, t, x.getMaxLit(), x.getMinLit());
 			//			setDom(y, setMax, t, x.getFMaxLit(t), x.getFMinLit(-t));
-			//			setDom(y, setMax, t, x.getLit(t+1, 2), x.getLit(-t-1, 3));
+			//			setDom(y, setMax, t, x.getLit(t+1, LR_GE), x.getLit(-t-1, LR_LE));
 		}
 
 		setDom(x, setMax, y.getMax(), y.getMaxLit());
@@ -768,5 +768,5 @@ void bool2int(BoolView x, IntVar* y) {
 	int_rel(y, IRT_GE, 0);
 	int_rel(y, IRT_LE, 1);
 	y->specialiseToEL();
-	bool_rel(x, BRT_EQ, BoolView(y->getLit(1, 2)));
+	bool_rel(x, BRT_EQ, BoolView(y->getLit(1, LR_GE)));
 }

--- a/chuffed/primitives/binary.cpp
+++ b/chuffed/primitives/binary.cpp
@@ -435,8 +435,8 @@ void int_rel_reif_real(IntVar* x, IntRelType t, int c, BoolView r) {
 		int_rel_reif(x, t, v, r);
 		return;
 	}
-	BoolView b1(x->getLit(c, 2));
-	BoolView b2(x->getLit(c, 3));
+	BoolView b1(x->getLit(c, LR_GE));
+	BoolView b2(x->getLit(c, LR_LE));
 	switch (t) {
 		case IRT_EQ:
 			bool_rel(b1, BRT_AND, b2, r);
@@ -475,8 +475,8 @@ void int_rel_half_reif_real(IntVar* x, IntRelType t, int c, BoolView r) {
 		int_rel_half_reif(x, t, v, r);
 		return;
 	}
-	BoolView b1(x->getLit(c, 2));
-	BoolView b2(x->getLit(c, 3));
+	BoolView b1(x->getLit(c, LR_GE));
+	BoolView b2(x->getLit(c, LR_LE));
 	switch (t) {
 		case IRT_EQ:
 			bool_rel(b2, BRT_OR, ~r);

--- a/chuffed/primitives/element.cpp
+++ b/chuffed/primitives/element.cpp
@@ -256,7 +256,7 @@ public:
 			int i = 0;
 			while (i <= a.size()) {
 				if (!x.indomain(i)) {
-					expl.push_back(x.getLit(i, 1));
+					expl.push_back(x.getLit(i, LR_EQ));
 				} else if (y.getMax() < a[i].getMin()) {
 					if (!push_max) {
 						expl.push_back(y.getMaxLit());
@@ -305,7 +305,7 @@ public:
 						r = Reason_new(a.size() + 2);
 						// Finesse lower bounds
 						for (int i = 0; i < a.size(); i++) {
-							(*r)[i + 2] = x.indomain(i) ? a[i].getFMinLit(new_m) : x.getLit(i, 1);
+							(*r)[i + 2] = x.indomain(i) ? a[i].getFMinLit(new_m) : x.getLit(i, LR_EQ);
 						}
 					}
 					return r;
@@ -350,7 +350,7 @@ public:
 						r = Reason_new(a.size() + 2);
 						// Finesse upper bounds
 						for (int i = 0; i < a.size(); i++) {
-							(*r)[i + 2] = x.indomain(i) ? a[i].getFMaxLit(new_m) : x.getLit(i, 1);
+							(*r)[i + 2] = x.indomain(i) ? a[i].getFMaxLit(new_m) : x.getLit(i, LR_EQ);
 						}
 					}
 					return r;
@@ -510,7 +510,7 @@ public:
 					r = Reason_new(a.size() + 1);
 					// Finesse lower bounds
 					for (int i = 0; i < a.size(); i++) {
-						(*r)[i + 1] = x.indomain(i) ? a[i].getFMinLit(new_m) : x.getLit(i, 1);
+						(*r)[i + 1] = x.indomain(i) ? a[i].getFMinLit(new_m) : x.getLit(i, LR_EQ);
 					}
 				}
 				if (!y.setMin(new_m, r)) {
@@ -544,7 +544,7 @@ public:
 					r = Reason_new(a.size() + 1);
 					// Finesse upper bounds
 					for (int i = 0; i < a.size(); i++) {
-						(*r)[i + 1] = x.indomain(i) ? a[i].getFMaxLit(new_m) : x.getLit(i, 1);
+						(*r)[i + 1] = x.indomain(i) ? a[i].getFMaxLit(new_m) : x.getLit(i, LR_EQ);
 					}
 				}
 				if (!y.setMax(new_m, r)) {
@@ -645,13 +645,12 @@ public:
 					(*r)[1] = x.getMinLit();
 					(*r)[2] = x.getMaxLit();
 					for (int i = x.getMin(); i <= x.getMax(); i++) {
-						//(*r)[3 + i - x.getMin()] = x.indomain(i) ? ~a[i].getLit(v, 0) : ~x.getLit(i, 0);
 						int reasonIndex = 3 + i - x.getMin();
 						if (x.indomain(i)) {
-							Lit l = ~a[i].getLit(v, 0);
+							Lit l = ~a[i].getLit(v, LR_NE);
 							(*r)[reasonIndex] = l;
 						} else {
-							Lit l = ~x.getLit(i, 0);
+							Lit l = ~x.getLit(i, LR_NE);
 							(*r)[reasonIndex] = l;
 						}
 					}
@@ -689,7 +688,8 @@ public:
 			for (typename IntView<W>::iterator i = a[v].begin(); i != a[v].end();) {
 				int w = *i++;
 				if (!y.indomain(w) &&
-						!a[v].remVal(w, so.lazy ? Reason(~y.getLit(w, 0), ~x.getLit(v, 1)) : Reason())) {
+						!a[v].remVal(w,
+												 so.lazy ? Reason(~y.getLit(w, LR_NE), ~x.getLit(v, LR_EQ)) : Reason())) {
 					return false;
 				}
 			}

--- a/chuffed/vars/int-var-el.cpp
+++ b/chuffed/vars/int-var-el.cpp
@@ -188,7 +188,7 @@ void IntVarEL::setBDecidable(bool b) const {
 	}
 }
 
-Lit IntVarEL::getLit(int64_t v, int t) {
+Lit IntVarEL::getLit(int64_t v, LitRel t) {
 	//    std::cerr << "IntVarEL::getLit\n";
 	if (v < lit_min) {
 		return toLit(1 ^ (t & 1));  // 1, 0, 1, 0
@@ -197,13 +197,13 @@ Lit IntVarEL::getLit(int64_t v, int t) {
 		return toLit(((t - 1) >> 1) & 1);  // 1, 0, 0, 1
 	}
 	switch (t) {
-		case 0:
+		case LR_NE:
 			return getNELit(v);
-		case 1:
+		case LR_EQ:
 			return getEQLit(v);
-		case 2:
+		case LR_GE:
 			return getGELit(v);
-		case 3:
+		case LR_LE:
 			return getLELit(v);
 		default:
 			NEVER;
@@ -318,7 +318,7 @@ inline void IntVarEL::updateFixed() {
 bool IntVarEL::setMin(int64_t v, Reason r, bool channel) {
 	assert(setMinNotR(v));
 	if (channel) {
-		sat.cEnqueue(getLit(v, 2), r);
+		sat.cEnqueue(getLit(v, LR_GE), r);
 	}
 	if (v > max) {
 		assert(sat.confl);
@@ -344,7 +344,7 @@ bool IntVarEL::setMin(int64_t v, Reason r, bool channel) {
 bool IntVarEL::setMax(int64_t v, Reason r, bool channel) {
 	assert(setMaxNotR(v));
 	if (channel) {
-		sat.cEnqueue(getLit(v, 3), r);
+		sat.cEnqueue(getLit(v, LR_LE), r);
 	}
 	if (v < min) {
 		assert(sat.confl);
@@ -370,7 +370,7 @@ bool IntVarEL::setMax(int64_t v, Reason r, bool channel) {
 bool IntVarEL::setVal(int64_t v, Reason r, bool channel) {
 	assert(setValNotR(v));
 	if (channel) {
-		sat.cEnqueue(getLit(v, 1), r);
+		sat.cEnqueue(getLit(v, LR_EQ), r);
 	}
 	if (!indomain(v)) {
 		assert(sat.confl);
@@ -397,7 +397,7 @@ bool IntVarEL::remVal(int64_t v, Reason r, bool channel) {
 	assert(remValNotR(v));
 	assert(vals);
 	if (channel) {
-		sat.cEnqueue(getLit(v, 0), r);
+		sat.cEnqueue(getLit(v, LR_NE), r);
 	}
 	if (isFixed()) {
 		assert(sat.confl);

--- a/chuffed/vars/int-var-el.h
+++ b/chuffed/vars/int-var-el.h
@@ -47,7 +47,7 @@ public:
 	Lit getEQLit2(int v) const { return toLit(base_vlit + 2 * v + 1); }
 
 	// t = 0: [x != v], t = 1: [x = v], t = 2: [x >= v], t = 3: [x <= v]
-	Lit getLit(int64_t v, int t) override;
+	Lit getLit(int64_t v, LitRel t) override;
 
 	Lit getMinLit() const override { return ~getGELit(min); }
 	Lit getMaxLit() const override { return ~getLELit(max); }
@@ -55,8 +55,8 @@ public:
 		assert(isFixed());
 		return ~getEQLit(min);
 	}
-	Lit getFMinLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->min, 2); }
-	Lit getFMaxLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->max, 3); }
+	Lit getFMinLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->min, LR_GE); }
+	Lit getFMaxLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->max, LR_LE); }
 
 	bool setMin(int64_t v, Reason r = nullptr, bool channel = true) override;
 	bool setMax(int64_t v, Reason r = nullptr, bool channel = true) override;

--- a/chuffed/vars/int-var-ll.cpp
+++ b/chuffed/vars/int-var-ll.cpp
@@ -151,7 +151,7 @@ inline Lit IntVarLL::getLELit(int v) {
 	return ~getGELit(v + 1);
 }
 
-Lit IntVarLL::getLit(int64_t v, int t) {
+Lit IntVarLL::getLit(int64_t v, LitRel t) {
 	// NOTE: Previous assertion that makes little sense. We should further
 	// investigate if the comparisons with min/max make sense at different
 	// decision levels.
@@ -164,9 +164,9 @@ Lit IntVarLL::getLit(int64_t v, int t) {
 		return toLit(t & 1);  // _, _, 0, 1
 	}
 	switch (t) {
-		case 2:
+		case LR_GE:
 			return getGELit(v);
-		case 3:
+		case LR_LE:
 			return getLELit(v);
 		default:
 			NEVER;

--- a/chuffed/vars/int-var-ll.h
+++ b/chuffed/vars/int-var-ll.h
@@ -36,7 +36,7 @@ public:
 
 	// NOTE: No support for INT_VAR_LL vars yet.
 	// t = 0: [x != v], t = 1: [x = v], t = 2: [x >= v], t = 3: [x <= v]
-	Lit getLit(int64_t v, int t) override;
+	Lit getLit(int64_t v, LitRel t) override;
 
 	Lit getMinLit() const override { return Lit(ld[li].var, false); }
 	Lit getMaxLit() const override { return Lit(ld[hi].var, true); }

--- a/chuffed/vars/int-var-sl.cpp
+++ b/chuffed/vars/int-var-sl.cpp
@@ -63,11 +63,11 @@ IntVarSL::IntVarSL(const IntVar& other, vec<int>& _values) : IntVar(other), valu
 
 	// rechannel channel info
 	for (int i = 0; i < values.size(); i++) {
-		Lit p = el->getLit(i, 0);
+		Lit p = el->getLit(i, LR_NE);
 		sat.c_info[var(p)].cons_id = var_id;
 	}
 	for (int i = 0; i <= values.size(); i++) {
-		Lit p = el->getLit(i, 2);
+		Lit p = el->getLit(i, LR_GE);
 		sat.c_info[var(p)].cons_id = var_id;
 	}
 
@@ -117,19 +117,19 @@ int IntVarSL::transform(int v, int type) {
 }
 
 // t = 0: [x != v], t = 1: [x = v], t = 2: [x >= v], t = 3: [x <= v]
-Lit IntVarSL::getLit(int64_t v, int t) {
+Lit IntVarSL::getLit(int64_t v, LitRel t) {
 	int u;
 	switch (t) {
-		case 0:
+		case LR_NE:
 			u = transform(v, 2);
-			return (u == -1 ? lit_True : el->getLit(u, 0));
-		case 1:
+			return (u == -1 ? lit_True : el->getLit(u, LR_NE));
+		case LR_EQ:
 			u = transform(v, 2);
-			return (u == -1 ? lit_False : el->getLit(u, 1));
-		case 2:
-			return el->getLit(transform(v, 1), 2);
-		case 3:
-			return el->getLit(transform(v, 0), 3);
+			return (u == -1 ? lit_False : el->getLit(u, LR_EQ));
+		case LR_GE:
+			return el->getLit(transform(v, 1), LR_LE);
+		case LR_LE:
+			return el->getLit(transform(v, 0), LR_GE);
 		default:
 			NEVER;
 	}

--- a/chuffed/vars/int-var-sl.h
+++ b/chuffed/vars/int-var-sl.h
@@ -21,16 +21,16 @@ public:
 	VarType getType() override { return INT_VAR_SL; }
 
 	// t = 0: [x != v], t = 1: [x = v], t = 2: [x >= v], t = 3: [x <= v]
-	Lit getLit(int64_t v, int t) override;
+	Lit getLit(int64_t v, LitRel t) override;
 
 	Lit getMinLit() const override { return el->getMinLit(); }
 	Lit getMaxLit() const override { return el->getMaxLit(); }
 	Lit getValLit() const override { return el->getValLit(); }
 	Lit getFMinLit(int64_t v) override {
-		return so.finesse ? ~el->getLit(transform(v, 0), 2) : el->getMinLit();
+		return so.finesse ? ~el->getLit(transform(v, 0), LR_GE) : el->getMinLit();
 	}
 	Lit getFMaxLit(int64_t v) override {
-		return so.finesse ? ~el->getLit(transform(v, 1), 3) : el->getMaxLit();
+		return so.finesse ? ~el->getLit(transform(v, 1), LR_LE) : el->getMaxLit();
 	}
 
 	bool setMin(int64_t v, Reason r = nullptr, bool channel = true) override;

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -321,7 +321,7 @@ public:
 
 		// NOTE: No support for INT_VAR_LL vars yet!
 		// t = 0: [x != v], t = 1: [x = v], t = 2: [x >= v], t = 3: [x <= v]
-		virtual Lit getLit(int64_t v, int t) { NEVER; }
+		virtual Lit getLit(int64_t v, LitRel t) { NEVER; }
 
 		//--------------------------------------------------
 		// Domain operations
@@ -341,16 +341,16 @@ public:
 
 		virtual void channel(int val, int val_type, int sign) { set(val, val_type * 3 ^ sign, false); }
 
-		Lit operator>=(int val) { return getLit(val, 2); }
-		Lit operator<=(int val) { return getLit(val, 3); }
-		Lit operator>(int val) { return getLit(val + 1, 2); }
-		Lit operator<(int val) { return getLit(val - 1, 3); }
-		Lit operator=(int val) { return getLit(val, 1); }
-		Lit operator!=(int val) { return getLit(val, 0); }
+		Lit operator>=(int val) { return getLit(val, LR_GE); }
+		Lit operator<=(int val) { return getLit(val, LR_LE); }
+		Lit operator>(int val) { return getLit(val + 1, LR_GE); }
+		Lit operator<(int val) { return getLit(val - 1, LR_LE); }
+		Lit operator=(int val) { return getLit(val, LR_EQ); }
+		Lit operator!=(int val) { return getLit(val, LR_NE); }
 
 		operator BoolView() {
 			assert(min >= 0 && max <= 1);
-			return getLit(1, 2);
+			return getLit(1, LR_GE);
 		}
 
 		//--------------------------------------------------

--- a/chuffed/vars/int-view.h
+++ b/chuffed/vars/int-view.h
@@ -268,10 +268,11 @@ public:
 		if ((type & 1) != 0) {
 			v = -v;
 			if (t >= 2) {
-				return var->getLit(v, 5 - t);
+				assert(5 - t >= 0 && 5 - t <= 3);
+				return var->getLit(v, static_cast<LitRel>(5 - t));
 			}
 		}
-		return var->getLit(v, t);
+		return var->getLit(v, static_cast<LitRel>(t));
 	}
 
 	// Set ![y <= m-1]
@@ -347,8 +348,8 @@ public:
 		return var->remVal(v, r, channel);
 	}
 
-	Lit operator=(int val) const { return getLit(val, 1); }
-	Lit operator!=(int val) const { return getLit(val, 0); }
+	Lit operator=(int val) const { return getLit(val, LR_EQ); }
+	Lit operator!=(int val) const { return getLit(val, LR_NE); }
 };
 
 const IntView<> iv_null;


### PR DESCRIPTION
A relatively minor change that will likely help with further development. This changes the `getLit` methods on integer variables to always to the `LitRel` type which shows what type of literal you are getting. The integers used previously were often very obscure.