### PR TITLE
Fix clang-tidy and compilation issues in the examples

### DIFF
--- a/chuffed/examples/blackhole.cpp
+++ b/chuffed/examples/blackhole.cpp
@@ -35,10 +35,13 @@ public:
 		for (bool& i : dealt) {
 			i = false;
 		}
+
+		std::default_random_engine rnd_engine;
+		std::uniform_int_distribution<int> rnd_card(1, cards);
 		for (int i = 0; i < piles; i++) {
 			for (int j = 0; j < layers; j++) {
 				int r;
-				while (dealt[r = myrand(so.rnd_seed) % (cards - 1) + 1]) {
+				while (dealt[r = rnd_card(rnd_engine)]) {
 					;
 				}
 				dealt[r] = true;

--- a/chuffed/mdd/CFG.h
+++ b/chuffed/mdd/CFG.h
@@ -183,10 +183,10 @@ public:
 	void prod(RSym p, const Rule& r) {
 		int r_id = rules.size();
 		rules.push_back(r.syms);
-		prods[symID(p.sym)].push_back(ProdInfo(p.cond, r_id));
+		prods[symID(p.sym)].emplace_back(p.cond, r_id);
 	}
 
-	void rulePush(int id, Sym r) { rules[id].push_back(r); }
+	void rulePush(int id, Sym r) { rules[id].emplace_back(r); }
 
 	void normalize() {
 		for (unsigned int ii = 0; ii < rules.size(); ii++) {
@@ -198,9 +198,9 @@ public:
 				nr[0] = rules[ii].back();
 				rules[ii].pop_back();
 
-				rules[ii].push_back(next);
+				rules[ii].emplace_back(next);
 				rules.push_back(nr);
-				prods[symID(next)].push_back(ProdInfo(nullptr, rules.size() - 1));
+				prods[symID(next)].emplace_back(nullptr, rules.size() - 1);
 			}
 		}
 	}

--- a/chuffed/vars/int-var-sl.cpp
+++ b/chuffed/vars/int-var-sl.cpp
@@ -127,9 +127,9 @@ Lit IntVarSL::getLit(int64_t v, LitRel t) {
 			u = transform(v, 2);
 			return (u == -1 ? lit_False : el->getLit(u, LR_EQ));
 		case LR_GE:
-			return el->getLit(transform(v, 1), LR_LE);
+			return el->getLit(transform(v, 1), LR_GE);
 		case LR_LE:
-			return el->getLit(transform(v, 0), LR_GE);
+			return el->getLit(transform(v, 0), LR_LE);
 		default:
 			NEVER;
 	}


### PR DESCRIPTION
Small fixes to get the examples to compile again and pass clang-tidy