### PR TITLE
Resolve inconsistency in finessed max/min for sparse literal variables

### DIFF
--- a/chuffed/core/conflict.cpp
+++ b/chuffed/core/conflict.cpp
@@ -600,7 +600,8 @@ void SAT::printLit(Lit p) {
 	printf("%d:", toInt(p));
 	ChannelInfo& ci = c_info[var(p)];
 	if (ci.cons_type == 1) {
-		engine.vars[ci.cons_id]->printLit(ci.val, ci.val_type * 3 ^ static_cast<int>(sign(p)));
+		engine.vars[ci.cons_id]->printLit(
+				ci.val, static_cast<LitRel>(ci.val_type * 3 ^ static_cast<int>(sign(p))));
 	} else if (ci.cons_type == 2) {
 		engine.propagators[ci.cons_id]->printLit(ci.val, sign(p));
 	} else {

--- a/chuffed/core/conflict.cpp
+++ b/chuffed/core/conflict.cpp
@@ -154,10 +154,14 @@ void SAT::analyze(int nodeid, std::set<int>& contributingNogoods) {
 
 #if DEBUG_VERBOSE
 	std::cerr << "out_learnt:";
-	for (int i = 0; i < out_learnt.size(); i++) std::cerr << " " << toInt(out_learnt[i]);
+	for (int i = 0; i < out_learnt.size(); i++) {
+		std::cerr << " " << toInt(out_learnt[i]);
+	}
 	std::cerr << "\n";
 	std::cerr << "out_learnt (interpreted):";
-	for (int i = 0; i < out_learnt.size(); i++) std::cerr << " " << litString[toInt(out_learnt[i])];
+	for (int i = 0; i < out_learnt.size(); i++) {
+		std::cerr << " " << litString[toInt(out_learnt[i])];
+	}
 	std::cerr << "\n";
 #endif
 

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -294,7 +294,7 @@ inline void Engine::makeDecision(DecInfo& di, int alt) {
 		else
 			getVarSizes(var_sizes);
 #endif
-		((IntVar*)di.var)->set(di.val, di.type ^ alt);
+		((IntVar*)di.var)->set(di.val, static_cast<LitRel>(di.type ^ alt));
 	} else {
 #if DEBUG_VERBOSE
 		std::cerr << "enqueing SAT literal: " << di.val << "^" << alt << " = " << (di.val ^ alt)

--- a/chuffed/core/engine.cpp
+++ b/chuffed/core/engine.cpp
@@ -670,10 +670,14 @@ RESULT Engine::search(const std::string& problemLabel) {
 		int myalt = (altpath.empty()) ? (-1) : (altpath[altpath.size() - 1]);
 #if DEBUG_VERBOSE
 		std::cerr << "propagate (";
-		for (int i = 0; i < nodepath.size(); i++) std::cerr << " " << nodepath[i];
+		for (int i : nodepath) {
+			std::cerr << " " << i;
+		}
 		std::cerr << ")\n";
 		std::cerr << "altpath (";
-		for (int i = 0; i < altpath.size(); i++) std::cerr << " " << altpath[i];
+		for (int i : altpath) {
+			std::cerr << " " << i;
+		}
 		std::cerr << ")\n";
 #endif
 		if (decisionLevel() >= decisionLevelTip.size()) {
@@ -797,7 +801,9 @@ RESULT Engine::search(const std::string& problemLabel) {
 #if DEBUG_VERBOSE
 					std::cerr << "after analyze, decisionLevel() is " << decisionLevel() << "\n";
 					std::cerr << "decisionLevelTip:";
-					for (int i = 0; i < decisionLevelTip.size(); i++) std::cerr << " " << decisionLevelTip[i];
+					for (int i : decisionLevelTip) {
+						std::cerr << " " << i;
+					}
 					std::cerr << "\n";
 #endif
 

--- a/chuffed/core/sat.cpp
+++ b/chuffed/core/sat.cpp
@@ -428,7 +428,8 @@ void SAT::enqueue(Lit p, Reason r) {
 	trail.last().push(p);
 	ChannelInfo& ci = c_info[v];
 	if (ci.cons_type == 1) {
-		engine.vars[ci.cons_id]->channel(ci.val, ci.val_type, static_cast<int>(sign(p)));
+		engine.vars[ci.cons_id]->channel(ci.val, static_cast<LitRel>(ci.val_type),
+																		 static_cast<int>(sign(p)));
 	}
 }
 

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -126,7 +126,7 @@ FlatZincSpace::FlatZincSpace(int intVars, int boolVars, int setVars)
 	s = this;
 }
 
-void FlatZincSpace::newIntVar(IntVarSpec* vs) {
+void FlatZincSpace::newIntVar(IntVarSpec* vs, const std::string& name) {
 	// Resizing of the vectors if required
 	if (intVarCount == iv.size()) {
 		const int newSize = intVarCount > 0 ? 2 * intVarCount : 1;
@@ -152,6 +152,7 @@ void FlatZincSpace::newIntVar(IntVarSpec* vs) {
 			AST::SetLit* sl = vs->domain.some();
 			if (sl->interval) {
 				v = ::newIntVar(sl->min, sl->max);
+				intVarString.insert(std::pair<IntVar*, std::string>(v, name));
 			} else {
 				vec<int> d;
 				for (int& i : sl->s) {
@@ -159,6 +160,7 @@ void FlatZincSpace::newIntVar(IntVarSpec* vs) {
 				}
 				sort((int*)d, (int*)d + d.size());
 				v = ::newIntVar(d[0], d.last());
+				intVarString.insert(std::pair<IntVar*, std::string>(v, name));
 				if ((d.last() - d[0] >= d.size() * mylog2(d.size())) ||
 						(d.size() <= so.eager_limit && (d.last() - d[0] + 1) > so.eager_limit)) {
 					new (v) IntVarSL(*v, d);

--- a/chuffed/flatzinc/flatzinc.h
+++ b/chuffed/flatzinc/flatzinc.h
@@ -319,7 +319,7 @@ public:
 	void fixAllSearch();
 
 	/// Create new integer variable from specification
-	void newIntVar(IntVarSpec* vs);
+	void newIntVar(IntVarSpec* vs, const std::string& name);
 	/// Create new Boolean variable from specification
 	void newBoolVar(BoolVarSpec* vs);
 	/// Create new set variable from specification

--- a/chuffed/flatzinc/generated_parser/parser.tab.cpp
+++ b/chuffed/flatzinc/generated_parser/parser.tab.cpp
@@ -237,9 +237,7 @@ void initfg(ParserState* pp) {
     for (unsigned int i = 0; i < pp->intvars.size(); i++) {
         if (!pp->hadError) {
             try {
-                pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
             } catch (FlatZinc::Error& e) {
                 yyerror(pp, e.toString().c_str());
             }
@@ -961,22 +959,22 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   486,   486,   488,   490,   493,   494,   498,   503,   511,
-     512,   516,   521,   529,   530,   537,   539,   541,   544,   545,
-     548,   551,   552,   553,   554,   557,   558,   559,   560,   563,
-     564,   567,   568,   575,   607,   638,   645,   677,   703,   713,
-     726,   783,   834,   842,   896,   909,   922,   930,   945,   949,
-     964,   988,   991,   997,  1002,  1008,  1010,  1013,  1019,  1023,
-    1038,  1062,  1065,  1071,  1076,  1083,  1089,  1093,  1108,  1132,
-    1135,  1141,  1146,  1153,  1156,  1160,  1175,  1199,  1202,  1208,
-    1213,  1220,  1227,  1230,  1237,  1240,  1247,  1250,  1257,  1260,
-    1266,  1284,  1305,  1328,  1336,  1353,  1357,  1361,  1367,  1371,
-    1385,  1386,  1393,  1397,  1406,  1409,  1415,  1420,  1428,  1431,
-    1437,  1442,  1450,  1453,  1459,  1464,  1472,  1475,  1481,  1487,
-    1499,  1503,  1510,  1514,  1521,  1524,  1530,  1534,  1538,  1542,
-    1546,  1595,  1609,  1612,  1618,  1622,  1633,  1654,  1684,  1706,
-    1707,  1715,  1718,  1724,  1728,  1735,  1740,  1746,  1750,  1758,
-    1761,  1767,  1771,  1777,  1781,  1785,  1789,  1793,  1836,  1847
+       0,   484,   484,   486,   488,   491,   492,   496,   501,   509,
+     510,   514,   519,   527,   528,   535,   537,   539,   542,   543,
+     546,   549,   550,   551,   552,   555,   556,   557,   558,   561,
+     562,   565,   566,   573,   605,   636,   643,   675,   701,   711,
+     724,   781,   832,   840,   894,   907,   920,   928,   943,   947,
+     962,   986,   989,   995,  1000,  1006,  1008,  1011,  1017,  1021,
+    1036,  1060,  1063,  1069,  1074,  1081,  1087,  1091,  1106,  1130,
+    1133,  1139,  1144,  1151,  1154,  1158,  1173,  1197,  1200,  1206,
+    1211,  1218,  1225,  1228,  1235,  1238,  1245,  1248,  1255,  1258,
+    1264,  1282,  1303,  1326,  1334,  1351,  1355,  1359,  1365,  1369,
+    1383,  1384,  1391,  1395,  1404,  1407,  1413,  1418,  1426,  1429,
+    1435,  1440,  1448,  1451,  1457,  1462,  1470,  1473,  1479,  1485,
+    1497,  1501,  1508,  1512,  1519,  1522,  1528,  1532,  1536,  1540,
+    1544,  1593,  1607,  1610,  1616,  1620,  1631,  1650,  1678,  1700,
+    1701,  1709,  1712,  1718,  1722,  1729,  1734,  1740,  1744,  1752,
+    1755,  1761,  1765,  1771,  1775,  1779,  1783,  1787,  1830,  1841
 };
 #endif
 
@@ -3234,9 +3232,7 @@ yyreduce:
             if (pp->fg != NULL) {
                 // Add a new IntVar to the FlatZincSpace if it was already created
                 try {
-                    pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                    IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                    intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                    pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -3259,9 +3255,7 @@ yyreduce:
                 if (pp->fg != NULL) {
                     // Add a new IntVar to the FlatZincSpace if it was already created
                     try {
-                        pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                        IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                        intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                        pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
                     } catch (FlatZinc::Error& e) {
                         yyerror(pp, e.toString().c_str());
                     }

--- a/chuffed/flatzinc/parser.yxx
+++ b/chuffed/flatzinc/parser.yxx
@@ -195,9 +195,7 @@ void initfg(ParserState* pp) {
     for (unsigned int i = 0; i < pp->intvars.size(); i++) {
         if (!pp->hadError) {
             try {
-                pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
             } catch (FlatZinc::Error& e) {
                 yyerror(pp, e.toString().c_str());
             }
@@ -1642,9 +1640,7 @@ solve_expr:
             if (pp->fg != NULL) {
                 // Add a new IntVar to the FlatZincSpace if it was already created
                 try {
-                    pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                    IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                    intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                    pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -1665,9 +1661,7 @@ solve_expr:
                 if (pp->fg != NULL) {
                     // Add a new IntVar to the FlatZincSpace if it was already created
                     try {
-                        pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second));
-                        IntVar* newiv = pp->fg->iv[pp->fg->intVarCount-1];
-                        intVarString.insert(std::pair<IntVar*, std::string>(newiv, pp->intvars[i].first));
+                        pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
                     } catch (FlatZinc::Error& e) {
                         yyerror(pp, e.toString().c_str());
                     }

--- a/chuffed/flatzinc/registry.cpp
+++ b/chuffed/flatzinc/registry.cpp
@@ -100,8 +100,7 @@ inline void arg2BoolVarArgs(vec<BoolView>& ia, AST::Node* arg) {
 		if (a->a[i]->isBoolVar()) {
 			ia[i] = s->bv[a->a[i]->getBoolVar()];
 		} else {
-			bool value = a->a[i]->getBool();
-			ia[i] = newBoolVar(static_cast<int>(value), static_cast<int>(value));
+			ia[i] = a->a[i]->getBool() ? bv_true : bv_false;
 		}
 	}
 }

--- a/chuffed/vars/int-var-sl.cpp
+++ b/chuffed/vars/int-var-sl.cpp
@@ -61,6 +61,16 @@ IntVarSL::IntVarSL(const IntVar& other, vec<int>& _values) : IntVar(other), valu
 	v->specialiseToEL();
 	el = (IntVarEL*)v;
 
+	// Override literal name values
+	std::string label = intVarString[el];
+	for (int i = 0; i < values.size(); i++) {
+		std::string val = std::to_string(values[i]);
+		litString[toInt(el->getLit(i, LR_NE))] = label + "!=" + val;
+		litString[toInt(el->getLit(i, LR_EQ))] = label + "==" + val;
+		litString[toInt(el->getLit(i, LR_GE))] = label + ">=" + val;
+		litString[toInt(el->getLit(i, LR_LE))] = label + "<=" + val;
+	}
+
 	// rechannel channel info
 	for (int i = 0; i < values.size(); i++) {
 		Lit p = el->getLit(i, LR_NE);

--- a/chuffed/vars/int-var-sl.cpp
+++ b/chuffed/vars/int-var-sl.cpp
@@ -202,9 +202,9 @@ bool IntVarSL::remVal(int64_t v, Reason r, bool channel) {
 	return true;
 }
 
-void IntVarSL::channel(int val, int val_type, int sign) {
+void IntVarSL::channel(int val, LitRel val_type, int sign) {
 	//	fprintf(stderr, "funny channel\n");
-	int type = val_type * 3 ^ sign;
+	auto type = static_cast<LitRel>(static_cast<int>(val_type) * 3 ^ sign);
 	el->set(val, type, false);
 	if (type == 0) {
 		vals[values[val]] = 0;

--- a/chuffed/vars/int-var-sl.h
+++ b/chuffed/vars/int-var-sl.h
@@ -38,7 +38,7 @@ public:
 	bool setVal(int64_t v, Reason r = nullptr, bool channel = true) override;
 	bool remVal(int64_t v, Reason r = nullptr, bool channel = true) override;
 
-	void channel(int val, int val_type, int sign) override;
+	void channel(int val, LitRel val_type, int sign) override;
 	void debug();
 };
 

--- a/chuffed/vars/int-var-sl.h
+++ b/chuffed/vars/int-var-sl.h
@@ -26,12 +26,8 @@ public:
 	Lit getMinLit() const override { return el->getMinLit(); }
 	Lit getMaxLit() const override { return el->getMaxLit(); }
 	Lit getValLit() const override { return el->getValLit(); }
-	Lit getFMinLit(int64_t v) override {
-		return so.finesse ? ~el->getLit(transform(v, 0), LR_GE) : el->getMinLit();
-	}
-	Lit getFMaxLit(int64_t v) override {
-		return so.finesse ? ~el->getLit(transform(v, 1), LR_LE) : el->getMaxLit();
-	}
+	Lit getFMinLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->min, LR_GE); }
+	Lit getFMaxLit(int64_t v) override { return ~getLit(so.finesse ? v : (int)this->max, LR_LE); }
 
 	bool setMin(int64_t v, Reason r = nullptr, bool channel = true) override;
 	bool setMax(int64_t v, Reason r = nullptr, bool channel = true) override;

--- a/chuffed/vars/int-var.h
+++ b/chuffed/vars/int-var.h
@@ -326,7 +326,7 @@ public:
 		//--------------------------------------------------
 		// Domain operations
 
-		void set(int val, int type, bool channel = true);
+		void set(int val, LitRel type, bool channel = true);
 
 		bool setMinNotR(int64_t v) const { return v > min; }
 		bool setMaxNotR(int64_t v) const { return v < max; }
@@ -339,7 +339,9 @@ public:
 		virtual bool remVal(int64_t v, Reason r = nullptr, bool channel = true);
 		virtual bool allowSet(vec<int>& v, Reason r = nullptr, bool channel = true);
 
-		virtual void channel(int val, int val_type, int sign) { set(val, val_type * 3 ^ sign, false); }
+		virtual void channel(int val, LitRel val_type, int sign) {
+			set(val, static_cast<LitRel>((static_cast<int>(val_type) * 3 ^ sign)), false);
+		}
 
 		Lit operator>=(int val) { return getLit(val, LR_GE); }
 		Lit operator<=(int val) { return getLit(val, LR_LE); }
@@ -356,7 +358,7 @@ public:
 		//--------------------------------------------------
 		// Debug
 
-		void printLit(int val, int type) const;
+		void printLit(int val, LitRel type) const;
 		void print() const;
 	};
 
@@ -375,18 +377,18 @@ public:
 		in_queue = false;
 	}
 
-	inline void IntVar::set(int val, int type, bool channel) {
+	inline void IntVar::set(int val, LitRel type, bool channel) {
 		switch (type) {
-			case 0:
+			case LR_NE:
 				remVal(val, nullptr, channel);
 				break;
-			case 1:
+			case LR_EQ:
 				setVal(val, nullptr, channel);
 				break;
-			case 2:
+			case LR_GE:
 				setMin(val + 1, nullptr, channel);
 				break;
-			case 3:
+			case LR_LE:
 				setMax(val, nullptr, channel);
 				break;
 			default:
@@ -394,19 +396,19 @@ public:
 		}
 	}
 
-	inline void IntVar::printLit(int val, int type) const {
+	inline void IntVar::printLit(int val, LitRel type) const {
 		printf("[v%d ", var_id);
 		switch (type) {
-			case 0:
+			case LR_NE:
 				printf("!= %d]", val);
 				break;
-			case 1:
+			case LR_EQ:
 				printf("== %d]", val);
 				break;
-			case 2:
+			case LR_GE:
 				printf(">= %d]", val + 1);
 				break;
-			case 3:
+			case LR_LE:
 				printf("<= %d]", val);
 				break;
 		}


### PR DESCRIPTION
Resolves #118 

This PR includes some other changes to improve debug-ability. Mostly the addition of (correct) labels, and some increases in the `LitRel` usage.