### PR TITLE
Set min and max before initializing vals in IntVarSL

### DIFF
--- a/chuffed/vars/int-var.cpp
+++ b/chuffed/vars/int-var.cpp
@@ -127,6 +127,13 @@ void IntVar::specialiseToSL(vec<int>& values) {
 	}
 	v.resize(j);
 
+	if (min < v[0]) {
+		min = v[0];
+	}
+	if (max > v[v.size() - 1]) {
+		max = v[v.size() - 1];
+	}
+
 	//	for (int i = 0; i < values.size(); i++) printf("%d ", values[i]);
 	//	printf("\n");
 


### PR DESCRIPTION
Small change to try and limit the size required for `vals` and avoid the `vals` not being able to be created.