### PR TITLE
Fixes incorrect behavior of the int_times function.

### DIFF
--- a/chuffed/primitives/arithmetic.cpp
+++ b/chuffed/primitives/arithmetic.cpp
@@ -580,8 +580,7 @@ void int_times(IntVar* x, IntVar* y, IntVar* z) {
 		} else if (x_flip && y_flip && !z_flip) {
 			new Times<1, 1, 0>(IntView<>(x), IntView<>(y), IntView<>(z));
 		} else {
-			// as: This case is an inconsistency in the model!
-			CHUFFED_ERROR("Cannot handle this case\n");
+			new TimesAll<0, 0, 0>(IntView<>(x), IntView<>(y), IntView<>(z));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #131.

It is incorrect that the last case of the int_times function represents only inconsistent models. The TimesAll propagator deals correctly with this last case.

More precisely, the function int_times checks whether the domain of one of the variables contains both a negative and a positive value. If it is the case, it creates a TimesAll propagator. Otherwise, the domain of all variables either contains no negative numbers or at least one negative number and no positive numbers. The function then checks if the domains respect the conditions of the Times propagator or if a pair of domains can be flipped so that they do. In that case, it creates a Times propagator with the correct transformation of the domains.

This leaves the case of 3 domains containing a negative value and no positive value, and the case of 2 domains containing no negative value and 1 domain containing a negative value and no positive value. The code used to consider these cases as untreatable and a sign of an inconsistant model, throwing an exception. However, these cases are treatable by the TimesAll propagator and are not always inconsistant. If it is truly inconsistant, the TimesAll will find it in its first propagation on the product variable. Otherwise, it will fix it to 0 and treat the factors correctly.