### PR TITLE
DisjunctiveEF: fix invalid inference for zero duration tasks

### DIFF
--- a/chuffed/globals/disjunctive.cpp
+++ b/chuffed/globals/disjunctive.cpp
@@ -328,6 +328,11 @@ public:
 				// add task to priority queue
 				pqueue.insert(task);
 
+				// no inference possible when zero time elapses
+				if (dur[task] == 0) {
+					continue;
+				}
+
 				// infer precedences by looking for bound b s.t.
 				// cur_time + dur[task] + sum_{t | let(t) <= b} residual[t] > b
 				int lets_i;


### PR DESCRIPTION
Small fix for a problem that occurred running a model instance used for MiniZinc course