### PR TITLE
Add branchScore method for BoolView

### DIFF
--- a/chuffed/vars/bool-view.cpp
+++ b/chuffed/vars/bool-view.cpp
@@ -10,3 +10,49 @@ void BoolView::attach(Propagator* p, int pos, int eflags) const {
 		sat.watches[2 * v + (1 - static_cast<int>(s))].push(we);
 	}
 }
+
+//-----
+// Branching stuff
+
+double BoolView::getScore(VarBranch vb) {
+	double min = 0;
+	double max = 1;
+	bool fixed = isFixed();
+	if (fixed) {
+		if (isTrue()) {
+			min = 1;
+		} else {
+			max = 0;
+		}
+	}
+	switch (vb) {
+		case VAR_MIN_MIN:
+			return -min;
+		case VAR_MIN_MAX:
+			return min;
+		case VAR_MAX_MIN:
+			return -max;
+		case VAR_MAX_MAX:
+			return max;
+		case VAR_SIZE_MIN:
+			return fixed ? 0 : -1;
+		case VAR_SIZE_MAX:
+			return fixed ? 0 : 1;
+		// TODO: Number of watches is only an estimate. Lit/Var can occur in more
+		// clauses, but not function as watch. Is there a better existing measure?
+		case VAR_DEGREE_MIN: {
+			vec<WatchElem>& ws = sat.watches[toInt(getValLit())];
+			return -ws.size();
+		}
+		case VAR_DEGREE_MAX: {
+			vec<WatchElem>& ws = sat.watches[toInt(getValLit())];
+			return ws.size();
+		}
+		case VAR_ACTIVITY:
+			return sat.activity[v];
+		case VAR_REGRET_MIN_MAX:
+			return fixed ? 0 : 1;
+		default:
+			NOT_SUPPORTED;
+	}
+}

--- a/chuffed/vars/bool-view.h
+++ b/chuffed/vars/bool-view.h
@@ -58,7 +58,7 @@ public:
 	// For Branching:
 
 	bool finished() override { return isFixed(); }
-	double getScore(VarBranch vb) override { NOT_SUPPORTED; }
+	double getScore(VarBranch vb) override;
 	DecInfo* branch() override {
 		return new DecInfo(nullptr, 2 * v + static_cast<int>((sat.polarity[v])));
 	}


### PR DESCRIPTION
This resolves an issue where chuffed can crash when using `bool_search` in MiniZinc.

Implementation follows the example of `IntVar`.

We noticed this in a model that was using a search annotation along the lines of:

```
:: seq_search([bool_search(x,smallest,indomain_split,complete),...])
```

It might make sense to actually transform some of the variable selections to `input_order` in the future as well, since Boolean search `smallest` does not actually make any difference.