### PR TITLE
Add missing mzn-stat-end message to flush statistics in MiniZinc

### DIFF
--- a/chuffed/core/stats.cpp
+++ b/chuffed/core/stats.cpp
@@ -82,6 +82,7 @@ void Engine::printStats() {
 			engine.propagators[i]->printStats();
 		}
 	}
+	printf("%%%%%%mzn-stat-end\n");
 }
 
 void Engine::checkMemoryUsage() {


### PR DESCRIPTION
Resolves #135