### PR TITLE
Fixes to posting problems in the tree, steiner and dag globals, and fix to the incorrect unsatisfiability with the connected constraint

### DIFF
--- a/chuffed/flatzinc/mznlib/fzn_tree_int.mzn
+++ b/chuffed/flatzinc/mznlib/fzn_tree_int.mzn
@@ -3,7 +3,6 @@ predicate chuffed_tree(
     int: E,
     array[int] of int: from,
     array[int] of int: to,
-    var int: r,
     array[int] of var bool: ns,
     array[int] of var bool: es,
 );
@@ -16,4 +15,4 @@ predicate fzn_tree(
     var int: r,
     array[int] of var bool: ns,
     array[int] of var bool: es,
-) = chuffed_tree(N, E, from, to, r, ns, es);
+) = ns[r] /\ chuffed_tree(N, E, from, to, ns, es);

--- a/chuffed/flatzinc/registry.cpp
+++ b/chuffed/flatzinc/registry.cpp
@@ -1289,7 +1289,7 @@ void p_steiner_tree_new(const ConExpr& ce, AST::Node* ann) {
 	vec<int> to;
 	arg2intargs(to, ce[3]);
 	vec<int> ws;
-	arg2intargs(to, ce[4]);
+	arg2intargs(ws, ce[4]);
 	vec<BoolView> vs;
 	arg2BoolVarArgs(vs, ce[5]);
 	vec<BoolView> es;
@@ -1543,23 +1543,27 @@ void p_dag_new(const ConExpr& ce, AST::Node* ann) {
 	vec<BoolView> es;
 	arg2BoolVarArgs(es, ce[3]);
 	int nb_nodes = vs.size();
-	int nb_edges = es.size();
 
 	int extra = nb_nodes;  // Extra node with edges to everyone
 	vs.push(bv_true);
+	vec<BoolView> new_edges;
 	for (int i = 0; i < nb_nodes; i++) {
-		from.push(extra);
-		to.push(i);
-		es.push(bv_true);
+		from.push(extra + 1);
+		to.push(i + 1);
+		BoolView new_edge = newBoolVar();
+		es.push(new_edge);
+		new_edges.push(new_edge);
 	}
 
 	vec<vec<int> > en;
 	vec<vec<int> > in;
 	vec<vec<int> > ou;
+	nb_nodes = vs.size();
 	for (int i = 0; i < nb_nodes; i++) {
 		in.push(vec<int>());
 		ou.push(vec<int>());
 	}
+	int nb_edges = es.size();
 	for (int i = 0; i < nb_edges; i++) {
 		en.push(vec<int>());
 		// The -1 is because indexes in MZ start at 1
@@ -1570,6 +1574,7 @@ void p_dag_new(const ConExpr& ce, AST::Node* ann) {
 		ou[u].push(i);
 		in[v].push(i);
 	}
+	bool_linear(new_edges, IRT_LE, getConstant(1));
 	dag(extra, vs, es, in, ou, en);
 }
 

--- a/chuffed/globals/tree.h
+++ b/chuffed/globals/tree.h
@@ -65,9 +65,9 @@ protected:
 
 	int articulations(int n, std::vector<bool>& reachable, int& count);
 	bool reachable(int n, std::vector<bool>& blue, bool doDFS = false);
-	void unite(int u, int v);
-	bool cycle_detect(int edge);
-	void precycle_detect(int unk_edge);
+	virtual void unite(int u, int v);
+	virtual bool cycle_detect(int edge);
+	virtual void precycle_detect(int unk_edge);
 	int newNodeCompleteCheckup_Count;
 	bool newNodeCompleteCheckup;
 
@@ -113,8 +113,23 @@ public:
 
 class ConnectedPropagator : public TreePropagator {
 protected:
-	static bool cycle_detect(int edge) { return true; }
-	void precycle_detect(int unk_edge) {}
+	bool cycle_detect(int edge) override { return true; }
+	void precycle_detect(int unk_edge) override {}
+
+	void unite(int u, int v) override {
+		if (uf.connected(u, v)) {
+			return;
+		}
+		if (!getNodeVar(u).isFixed()) {
+			uf.unite(u, v);
+			ruf.unite(u, v);
+			assert(ruf.isRoot(v));
+		} else {
+			uf.unite(v, u);
+			ruf.unite(v, u);
+			assert(ruf.isRoot(u));
+		}
+	}
 
 public:
 	ConnectedPropagator(vec<BoolView>& _vs, vec<BoolView>& _es, vec<vec<edge_id> >& _adj,


### PR DESCRIPTION
Fix #140

For the problem with the posting of the tree constraint, the root parameter has simply been removed from the chuffed_tree predicate in the relevant mzn. To maintain consistency with the Minizinc decomposition, a constraint verifying that the root is in the sub-graph is added.

For the steiner constraint, the fix is simply to initialize the weight vector when posting.

Finally, for dag, the first fix is to make sure that the new edges and the new node are added in all the relevant vectors. For that, it suffice to update "nb_nodes" and "nb_edges" before the loops and adding 1 to the nodes added in "from" and "to" (to be consistent with the node indexes in these vectors). The rest of the modifications concerns the new edges added. By having them be "bv_true", all nodes given were also set to true. From my understanding, the reason an extra node is added is so that the DReachability propagator can have a fixed root without us having to choose it in the graph given. By treating the new edges as unfixed boolean variables and adding a cardinality constraint on them should guaranty the wanted behaviour.