### PR TITLE
Fix ordering of `CHUFFED_LIBRARIES`

### DIFF
--- a/chuffed-config.cmake.in
+++ b/chuffed-config.cmake.in
@@ -4,7 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/chuffed-targets.cmake")
 
 check_required_components(chuffed chuffed_fzn)
 
-set(CHUFFED_LIBRARIES chuffed chuffed_fzn)
+set(CHUFFED_LIBRARIES chuffed_fzn chuffed)
 set(CHUFFED_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR})
 set(CHUFFED_SHARE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_DATAROOTDIR})
 set(CHUFFED_FOUND TRUE)


### PR DESCRIPTION
GCC on ARM needs this to actually be in the correct order