### PR TITLE
Add support for the experimental on_restart MiniZinc interface

### DIFF
--- a/chuffed/flatzinc/generated_parser/parser.tab.cpp
+++ b/chuffed/flatzinc/generated_parser/parser.tab.cpp
@@ -244,7 +244,7 @@ void initfg(ParserState* pp) {
         }
         if (pp->intvars[i].first[0] != '[') {
             delete pp->intvars[i].second;
-            pp->intvars[i].second = NULL;
+            pp->intvars[i].second = nullptr;
         }
     }
     for (unsigned int i = 0; i < pp->boolvars.size(); i++) {
@@ -269,7 +269,7 @@ void initfg(ParserState* pp) {
         }
         if (pp->boolvars[i].first[0] != '[') {
             delete pp->boolvars[i].second;
-            pp->boolvars[i].second = NULL;
+            pp->boolvars[i].second = nullptr;
         }
     }
     for (unsigned int i = 0; i < pp->setvars.size(); i++) {
@@ -282,14 +282,14 @@ void initfg(ParserState* pp) {
         }            
         if (pp->setvars[i].first[0] != '[') {
             delete pp->setvars[i].second;
-            pp->setvars[i].second = NULL;
+            pp->setvars[i].second = nullptr;
         }
     }
     for (unsigned int i = pp->domainConstraints.size(); i--;) {
         if (!pp->hadError) {
             try {
                 assert(pp->domainConstraints[i]->args->a.size() == 2);
-                pp->fg->postConstraint(*pp->domainConstraints[i], NULL);
+                FlatZinc::FlatZincSpace::postConstraint(*pp->domainConstraints[i], nullptr);
                 delete pp->domainConstraints[i];
             } catch (FlatZinc::Error& e) {
                 yyerror(pp, e.toString().c_str());              
@@ -300,7 +300,7 @@ void initfg(ParserState* pp) {
     for (int i = 0; i < static_cast<int>(pp->domainConstraints2.size()); ++i) {
         if (!pp->hadError) {
             try {
-                pp->fg->postConstraint(*pp->domainConstraints2[i].first, pp->domainConstraints2[i].second);
+                FlatZinc::FlatZincSpace::postConstraint(*pp->domainConstraints2[i].first, pp->domainConstraints2[i].second);
                 delete pp->domainConstraints2[i].first;
                 delete pp->domainConstraints2[i].second;
             } catch (FlatZinc::Error& e) {
@@ -312,7 +312,7 @@ void initfg(ParserState* pp) {
 }
 
 AST::Node* arrayOutput(AST::Call* ann) {
-    AST::Array* a = NULL;
+    AST::Array* a = nullptr;
     
     if (ann->args->isArray()) {
         a = ann->args->getArray();
@@ -341,7 +341,7 @@ AST::Node* arrayOutput(AST::Call* ann) {
     }
 
     if (!ann->args->isArray()) {
-        a->a[0] = NULL;
+        a->a[0] = nullptr;
         delete a;
     }
     return new AST::String(oss.str());
@@ -2232,7 +2232,7 @@ yyreduce:
             ParserState* pp = static_cast<ParserState*>(parm);
             yyassert(pp, !(yyvsp[-5].oSet)() || !(yyvsp[-5].oSet).some()->empty(), "Empty set domain.");
             yyassert(pp, (yyvsp[0].arg)->isSet(), "Invalid set initializer.");
-            AST::SetLit* set = NULL;
+            AST::SetLit* set = nullptr;
             if ((yyvsp[0].arg)->isSet())
                 set = (yyvsp[0].arg)->getSet();
             pp->setvals.put((yyvsp[-3].sValue), *set);
@@ -2858,7 +2858,7 @@ yyreduce:
                     pp->fg->enable_store_solution = true;
                 } else {
                     try {
-                        pp->fg->postConstraint(c, (yyvsp[0].argVec));
+                        FlatZinc::FlatZincSpace::postConstraint(c, (yyvsp[0].argVec));
                     } catch (FlatZinc::Error& e) {
                         yyerror(pp, e.toString().c_str());
                     }
@@ -2882,7 +2882,7 @@ yyreduce:
             ConExpr c("bool_eq", args);
             if (!pp->hadError) {
                 try {
-                    pp->fg->postConstraint(c, (yyvsp[0].argVec));
+                    FlatZinc::FlatZincSpace::postConstraint(c, (yyvsp[0].argVec));
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -2905,7 +2905,7 @@ yyreduce:
             ConExpr c("bool_eq", args);
             if (!pp->hadError) {
                 try {
-                    pp->fg->postConstraint(c, (yyvsp[0].argVec));
+                    FlatZinc::FlatZincSpace::postConstraint(c, (yyvsp[0].argVec));
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -3256,7 +3256,7 @@ yyreduce:
             pp->intvarTable.put(objname, i);
             pp->intvars.push_back(varspec(objname,
                 new IntVarSpec((yyvsp[0].iValue),false,true,false)));
-            if (pp->fg != NULL) {
+            if (pp->fg != nullptr) {
                 // Add a new IntVar to the FlatZincSpace if it was already created
                 try {
                     pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
@@ -3279,7 +3279,7 @@ yyreduce:
                 pp->intvarTable.put((yyvsp[0].sValue), i);
                 pp->intvars.push_back(varspec((yyvsp[0].sValue),
                     new IntVarSpec(tmp,false,true,false)));
-                if (pp->fg != NULL) {
+                if (pp->fg != nullptr) {
                     // Add a new IntVar to the FlatZincSpace if it was already created
                     try {
                         pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
@@ -3322,7 +3322,7 @@ yyreduce:
 
   case 141: /* annotations: %empty  */
         { 
-            (yyval.argVec) = NULL; 
+            (yyval.argVec) = nullptr; 
         }
     break;
 

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_complete.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_complete.mzn
@@ -1,0 +1,3 @@
+/* Abandon and mark search as complete when argument variable is assigned `true'. */
+predicate fzn_on_restart_complete(var bool: marker) = chuffed_on_restart_complete(marker);
+predicate chuffed_on_restart_complete(var bool: marker);

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_last_val_bool.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_last_val_bool.mzn
@@ -1,0 +1,3 @@
+/* Set `out` to be a the last assigned value of `input` on each restart */
+predicate fzn_on_restart_last_val_bool(var bool: input, var bool: out) = chuffed_on_restart_last_val_bool(input, out);
+predicate chuffed_on_restart_last_val_bool(var bool: input, var bool: out)

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_last_val_int.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_last_val_int.mzn
@@ -1,0 +1,3 @@
+/* Set `out` to be a the last assigned value of `input` on each restart */
+predicate fzn_on_restart_last_val_int(var int: input, var int: out) = chuffed_on_restart_last_val_int(input, out);
+predicate chuffed_on_restart_last_val_int(var int: input, var int: out)

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_sol_bool.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_sol_bool.mzn
@@ -1,0 +1,3 @@
+/* Set `out` to be a the last solution value of `input` on each restart */
+predicate fzn_on_restart_sol_bool(var bool: input, var bool: out) = chuffed_on_restart_sol_bool(input, out);
+predicate chuffed_on_restart_sol_bool(var bool: input, var bool: out);

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_sol_int.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_sol_int.mzn
@@ -1,0 +1,3 @@
+/* Set `out` to be a the last solution value of `input` on each restart */
+predicate fzn_on_restart_sol_int(var int: input, var int: out) = chuffed_on_restart_sol_int(input, out);
+predicate chuffed_on_restart_sol_int(var int: input, var int: out);

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_status.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_status.mzn
@@ -1,0 +1,13 @@
+/* 
+  Set the variable `s` to one of the following numbers before solving and after
+  each restart to reflect the result of searching since the last restart:
+	 - 1 (START) -> The solver has not yet been restarted
+	 - 2 (UNKNOWN) -> No solution has been found since the last restart
+	 - 3 (UNSAT) -> The search space was (provably) exhausted and no solution was
+     found since the last restart
+	 - 4 (SAT) -> A solution was found since the last restart
+	 - 5 (OPT) -> The (provably) optimal solution for the search space was found
+     since the last restart
+*/
+predicate fzn_on_restart_status(var int: s) = chuffed_on_restart_status(s);
+predicate chuffed_on_restart_status(var int: s)

--- a/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_uniform_int.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/on_restart/fzn_on_restart_uniform_int.mzn
@@ -1,0 +1,3 @@
+/* Set `out` to be a random value between `low` and `high` (inclusive) from a uniform distribution */
+predicate fzn_on_restart_uniform_int(int: low, int: high, var int: out) = chuffed_on_restart_uniform_int(low, high, out);
+predicate chuffed_on_restart_uniform_int(int: low, int: high, var int: out);

--- a/chuffed/flatzinc/parser.yxx
+++ b/chuffed/flatzinc/parser.yxx
@@ -1269,10 +1269,35 @@ constraint_item :
 #else
             ConExpr c($2, $4);
             if (!pp->hadError) {
-                try {
-                    pp->fg->postConstraint(c, $6);
-                } catch (FlatZinc::Error& e) {
-                    yyerror(pp, e.toString().c_str());
+                if (c.id == "chuffed_on_restart_status") {
+                    pp->fg->restart_status = c.args->a[0]->getIntVar();
+                    pp->fg->enable_on_restart = true;
+                } else if (c.id == "chuffed_on_restart_complete") {
+                    mark_complete(pp->fg->bv[c.args->a[0]->getBoolVar()], &pp->fg->mark_complete);
+                    pp->fg->enable_on_restart = true;
+                } else if (c.id == "chuffed_on_restart_uniform_int") {
+                    pp->fg->int_uniform.emplace_back(std::array<int, 3>{ c.args->a[0]->getInt(), c.args->a[1]->getInt(), c.args->a[2]->getIntVar() });
+                    pp->fg->enable_on_restart = true;
+                } else if (c.id == "chuffed_on_restart_last_val_bool") {
+                    pp->last_val_bool.emplace_back(c.args->a[0]->getBoolVar(), c.args->a[1]->getBoolVar());
+                    pp->fg->enable_on_restart = true;
+                } else if (c.id == "chuffed_on_restart_last_val_int") {
+                    pp->last_val_int.emplace_back(c.args->a[0]->getIntVar(), c.args->a[1]->getIntVar());
+                    pp->fg->enable_on_restart = true;
+                } else if (c.id == "chuffed_on_restart_sol_bool") {
+                    pp->fg->bool_sol.emplace_back(std::tuple<int, bool, int>{ c.args->a[0]->getBoolVar(), false, c.args->a[1]->getBoolVar() });
+                    pp->fg->enable_on_restart = true;
+                    pp->fg->enable_store_solution = true;
+                } else if (c.id == "chuffed_on_restart_sol_int") {
+                    pp->fg->int_sol.emplace_back(std::array<int, 3>{ c.args->a[0]->getIntVar(), 0, c.args->a[1]->getIntVar() });
+                    pp->fg->enable_on_restart = true;
+                    pp->fg->enable_store_solution = true;
+                } else {
+                    try {
+                        pp->fg->postConstraint(c, $6);
+                    } catch (FlatZinc::Error& e) {
+                        yyerror(pp, e.toString().c_str());
+                    }
                 }
             }
             delete $6;
@@ -1329,6 +1354,7 @@ solve_item :
             if (!pp->hadError) {
                 pp->fg->solve($2);
             }
+            pp->postOnRestartPropagators();
             delete $2;
         }
     |   SOLVE annotations minmax solve_expr
@@ -1340,6 +1366,7 @@ solve_item :
                 else
                     pp->fg->maximize($4,$2);
             }
+            pp->postOnRestartPropagators();
             delete $2;
         }
 

--- a/chuffed/flatzinc/parser.yxx
+++ b/chuffed/flatzinc/parser.yxx
@@ -202,7 +202,7 @@ void initfg(ParserState* pp) {
         }
         if (pp->intvars[i].first[0] != '[') {
             delete pp->intvars[i].second;
-            pp->intvars[i].second = NULL;
+            pp->intvars[i].second = nullptr;
         }
     }
     for (unsigned int i = 0; i < pp->boolvars.size(); i++) {
@@ -227,7 +227,7 @@ void initfg(ParserState* pp) {
         }
         if (pp->boolvars[i].first[0] != '[') {
             delete pp->boolvars[i].second;
-            pp->boolvars[i].second = NULL;
+            pp->boolvars[i].second = nullptr;
         }
     }
     for (unsigned int i = 0; i < pp->setvars.size(); i++) {
@@ -240,14 +240,14 @@ void initfg(ParserState* pp) {
         }            
         if (pp->setvars[i].first[0] != '[') {
             delete pp->setvars[i].second;
-            pp->setvars[i].second = NULL;
+            pp->setvars[i].second = nullptr;
         }
     }
     for (unsigned int i = pp->domainConstraints.size(); i--;) {
         if (!pp->hadError) {
             try {
                 assert(pp->domainConstraints[i]->args->a.size() == 2);
-                pp->fg->postConstraint(*pp->domainConstraints[i], NULL);
+                FlatZinc::FlatZincSpace::postConstraint(*pp->domainConstraints[i], nullptr);
                 delete pp->domainConstraints[i];
             } catch (FlatZinc::Error& e) {
                 yyerror(pp, e.toString().c_str());              
@@ -258,7 +258,7 @@ void initfg(ParserState* pp) {
     for (int i = 0; i < static_cast<int>(pp->domainConstraints2.size()); ++i) {
         if (!pp->hadError) {
             try {
-                pp->fg->postConstraint(*pp->domainConstraints2[i].first, pp->domainConstraints2[i].second);
+                FlatZinc::FlatZincSpace::postConstraint(*pp->domainConstraints2[i].first, pp->domainConstraints2[i].second);
                 delete pp->domainConstraints2[i].first;
                 delete pp->domainConstraints2[i].second;
             } catch (FlatZinc::Error& e) {
@@ -270,7 +270,7 @@ void initfg(ParserState* pp) {
 }
 
 AST::Node* arrayOutput(AST::Call* ann) {
-    AST::Array* a = NULL;
+    AST::Array* a = nullptr;
     
     if (ann->args->isArray()) {
         a = ann->args->getArray();
@@ -299,7 +299,7 @@ AST::Node* arrayOutput(AST::Call* ann) {
     }
 
     if (!ann->args->isArray()) {
-        a->a[0] = NULL;
+        a->a[0] = nullptr;
         delete a;
     }
     return new AST::String(oss.str());
@@ -713,7 +713,7 @@ vardecl_item :
             ParserState* pp = static_cast<ParserState*>(parm);
             yyassert(pp, !$3() || !$3.some()->empty(), "Empty set domain.");
             yyassert(pp, $8->isSet(), "Invalid set initializer.");
-            AST::SetLit* set = NULL;
+            AST::SetLit* set = nullptr;
             if ($8->isSet())
                 set = $8->getSet();
             pp->setvals.put($5, *set);
@@ -1294,7 +1294,7 @@ constraint_item :
                     pp->fg->enable_store_solution = true;
                 } else {
                     try {
-                        pp->fg->postConstraint(c, $6);
+                        FlatZinc::FlatZincSpace::postConstraint(c, $6);
                     } catch (FlatZinc::Error& e) {
                         yyerror(pp, e.toString().c_str());
                     }
@@ -1316,7 +1316,7 @@ constraint_item :
             ConExpr c("bool_eq", args);
             if (!pp->hadError) {
                 try {
-                    pp->fg->postConstraint(c, $3);
+                    FlatZinc::FlatZincSpace::postConstraint(c, $3);
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -1337,7 +1337,7 @@ constraint_item :
             ConExpr c("bool_eq", args);
             if (!pp->hadError) {
                 try {
-                    pp->fg->postConstraint(c, $6);
+                    FlatZinc::FlatZincSpace::postConstraint(c, $6);
                 } catch (FlatZinc::Error& e) {
                     yyerror(pp, e.toString().c_str());
                 }
@@ -1664,7 +1664,7 @@ solve_expr:
             pp->intvarTable.put(objname, i);
             pp->intvars.push_back(varspec(objname,
                 new IntVarSpec($1,false,true,false)));
-            if (pp->fg != NULL) {
+            if (pp->fg != nullptr) {
                 // Add a new IntVar to the FlatZincSpace if it was already created
                 try {
                     pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
@@ -1685,7 +1685,7 @@ solve_expr:
                 pp->intvarTable.put($1, i);
                 pp->intvars.push_back(varspec($1,
                     new IntVarSpec(tmp,false,true,false)));
-                if (pp->fg != NULL) {
+                if (pp->fg != nullptr) {
                     // Add a new IntVar to the FlatZincSpace if it was already created
                     try {
                         pp->fg->newIntVar(static_cast<IntVarSpec*>(pp->intvars[i].second), pp->intvars[i].first);
@@ -1734,7 +1734,7 @@ minmax:
 annotations :
         /* empty */
         { 
-            $$ = NULL; 
+            $$ = nullptr; 
         }
     |   annotations_head
         { 

--- a/chuffed/primitives/domain.cpp
+++ b/chuffed/primitives/domain.cpp
@@ -21,3 +21,53 @@ public:
 };
 
 void range_size(IntVar* x, IntVar* y) { new RangeSize(x, y); }
+
+template <class Var, class Val>
+class LastVal : public Propagator {
+public:
+	Var* x;
+	Val* v;
+
+	LastVal(Var* _x, Val* _v) : x(_x), v(_v) {
+		priority = 0;
+		x->attach(this, 0, EVENT_F);
+	}
+
+	void wakeup(int i, int c) override {
+		assert(x->isFixed());
+		pushInQueue();
+	}
+
+	bool propagate() override {
+		(*v) = x->getVal();
+		return true;
+	}
+};
+
+void last_val(IntVar* x, int* v) { new LastVal<IntVar, int>(x, v); }
+void last_val(BoolView* x, bool* v) { new LastVal<BoolView, bool>(x, v); }
+
+class Complete : public Propagator {
+public:
+	BoolView x;
+	bool* v;
+
+	Complete(BoolView _x, bool* _v) : x(std::move(_x)), v(_v) {
+		priority = 0;
+		x.attach(this, 0, EVENT_F);
+	}
+
+	void wakeup(int i, int c) override {
+		assert(x.isFixed());
+		pushInQueue();
+	}
+
+	bool propagate() override {
+		if (x.isTrue()) {
+			(*v) = true;
+		}
+		return true;
+	}
+};
+
+void mark_complete(BoolView x, bool* v) { new Complete(x, v); }

--- a/chuffed/primitives/primitives.h
+++ b/chuffed/primitives/primitives.h
@@ -161,4 +161,9 @@ void array_var_int_element_bound_imp(BoolView b, IntVar* x, vec<IntVar*>& a, Int
 // y = |ub(x) - lb(y) + 1|
 void range_size(IntVar* x, IntVar* y);
 
+void last_val(IntVar* x, int* v);
+void last_val(BoolView* x, bool* v);
+
+void mark_complete(BoolView x, bool* v);
+
 #endif


### PR DESCRIPTION
This pull request add support for the experimental "on_restart" search definitions. These definitions where first introduced in

Dekker, J.J., Banda, M.G., Schutt, A., Stuckey, P.J., & Tack, G. (2018). Solver-Independent Large Neighbourhood Search. International Conference on Principles and Practice of Constraint Programming.

as an easy way to use large neighbourhood search from a modelling languages without placing a large burden on the solvers.

The work was further expanded in my PhD thesis to include different types of meta (heuristic) search:

Dekker, Jip Joris (2021). A Modern Architecture for Constraint Modelling Languages. Monash University. Thesis. https://doi.org/10.26180/16968229.v1

