### PR TITLE
Allow cmake unity build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,15 @@ else()
   set(FLEX_FZNLexer_OUTPUTS ${PROJECT_SOURCE_DIR}/chuffed/flatzinc/generated_parser/lexer.yy.cpp)
 endif()
 
+# If CMAKE_UNITY_BUILD is enabled, we still want these files to be built separately
+# to avoid compilation errors.
+set_source_files_properties(
+    ${BISON_FZNParser_OUTPUTS}
+    ${FLEX_FZNLexer_OUTPUTS}
+  PROPERTIES
+    SKIP_UNITY_BUILD_INCLUSION ON
+)
+
 add_library(flatzinc_parser OBJECT
   ${FLEX_FZNLexer_OUTPUTS}
   ${BISON_FZNParser_OUTPUTS}

--- a/chuffed/support/lengauer_tarjan.h
+++ b/chuffed/support/lengauer_tarjan.h
@@ -1,3 +1,6 @@
+#ifndef LENGAUER_TARJAN_H
+#define LENGAUER_TARJAN_H
+
 #include <vector>
 
 class LengauerTarjan {
@@ -49,3 +52,5 @@ public:
 	virtual bool ignore_node(int u);
 	virtual bool ignore_edge(int e);
 };
+
+#endif


### PR DESCRIPTION
I'm looking at doing Rust bindings for this and it would pull and build the sources. It would be nice to enable `CMAKE_UNITY_BUILD` in our build script to shorten up the build times.

On an old MacBook Pro (Intel, 2017 model), this is a decent improvement in build times.

In a regular build (with `ninja`):

```
❯ time ninja
[65/71] Linking CXX static library libchuffed.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libchuffed.a(template.cpp.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libchuffed.a(template.cpp.o) has no symbols
[71/71] Linking CXX executable fzn-chuffed
ninja  172.71s user 13.36s system 677% cpu 27.482 total
```

And with `cmake -DCMAKE_UNITY_BUILD=ON -GNinja ...`:

```
❯ time ninja
[12/16] Building CXX object CMakeFiles/chuffed.dir/Unity/unity_3_cxx.cxx.o
In file included from /Users/bruce/Development/configura/chuffed/ub/CMakeFiles/chuffed.dir/Unity/unity_3_cxx.cxx:22:
/Users/bruce/Development/configura/chuffed/chuffed/globals/minimum_weight_tree.cpp:30:9: warning: 'MIN' macro redefined [-Wmacro-redefined]
#define MIN(a, b) (((a) < (b)) ? (a) : (b))
        ^
/Users/bruce/Development/configura/chuffed/chuffed/globals/tree.cpp:17:9: note: previous definition is here
#define MIN(a, b) ((a) < (b) ? (a) : (b))
        ^
1 warning generated.
[16/16] Linking CXX executable fzn-chuffed
ninja  84.39s user 3.23s system 661% cpu 13.236 total
```

So, we can see that it went from 27s to 13s in terms of total time.

I could add a CI config for this as well if there's interest.

(I'll submit a separate PR about `MIN`)
