### PR TITLE
Use `std::min` consistently rather than `MIN`.

### DIFF
--- a/chuffed/globals/minimum_weight_tree.cpp
+++ b/chuffed/globals/minimum_weight_tree.cpp
@@ -27,8 +27,6 @@
 using namespace std;
 #define TREEPROP_DEBUG 0
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 //*
 // This version needs to work in conjucntion with a TreePropagator
 // It won't do the propagations of treeness, only inherits from it

--- a/chuffed/globals/mst.cpp
+++ b/chuffed/globals/mst.cpp
@@ -2,14 +2,11 @@
 #include <chuffed/globals/tree.h>
 #include <chuffed/support/union_find.h>
 
-#include <algorithm>  // std::sort
+#include <algorithm>  // std::min, std::sort
 #include <iostream>
 #include <set>
 
 using namespace std;
-
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 #define MSTPROP_DEBUG 0
 
@@ -373,11 +370,11 @@ class DCMSTSearch : public BranchGroup {
 				int j = mst_p->getEndnode(e, 1);
 				// Is v the MIN or the SUM?? Its not clear from the paper that
 				// describes the searchs trategy....
-				int v = MIN(tmp[i].second, tmp[j].second);
+				int v = std::min(tmp[i].second, tmp[j].second);
 				sums.emplace_back(e, v);
 				vector<std::pair<int, int> > cost;
 				for (int k = 0; k < mst_p->nbNodes(); k++) {
-					cost.emplace_back(k, MIN(dist[i][k], dist[j][k]));
+					cost.emplace_back(k, std::min(dist[i][k], dist[j][k]));
 				}
 				sort(cost.begin(), cost.end(), sortPairKey2);
 				reverse(cost.begin(), cost.end());

--- a/chuffed/globals/tree.cpp
+++ b/chuffed/globals/tree.cpp
@@ -2,6 +2,7 @@
 #include <chuffed/globals/tree.h>
 #include <chuffed/support/union_find.h>
 
+#include <algorithm>
 #include <iostream>
 #include <queue>
 #include <set>
@@ -13,8 +14,6 @@
 using namespace std;
 
 #define TREEPROP_DEBUG 0
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /**
  * Detect that whe cannot reach some otehr node from 'node'
@@ -388,11 +387,11 @@ void TreePropagator::_findAndBuildBridges(int u, int& count, std::stack<edge_id>
 				hits.pop();
 			}
 
-			low[u] = MIN(low[u], low[v]);
+			low[u] = std::min(low[u], low[v]);
 		} else if (parent[u] != v && depth[v] < depth[u]) {
 			// e is a backedge from u to its ancestor v
 			s.push(e);
-			low[u] = MIN(low[u], depth[v]);
+			low[u] = std::min(low[u], depth[v]);
 		}
 	}
 

--- a/chuffed/support/dynamic_kmeans.h
+++ b/chuffed/support/dynamic_kmeans.h
@@ -13,8 +13,6 @@
 #include <set>
 #include <vector>
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 template <typename T>
 class ClusteringAlgorithm {
 protected:
@@ -114,7 +112,7 @@ public:
 				} else if ((inf == 0) && (inf2 != 0)) {
 					d = d1;
 				} else if ((inf == 0) && (inf2 == 0)) {
-					d = MIN(d1, d2);
+					d = std::min(d1, d2);
 				} else if ((inf != 0) && (inf2 != 0)) {
 					continue;  // Go to another cluster
 				}
@@ -158,7 +156,7 @@ public:
 						} else if ((inf == 0) && (inf2 != 0)) {
 							d = d1;
 						} else if ((inf == 0) && (inf2 == 0)) {
-							d = MIN(d1, d2);
+							d = std::min(d1, d2);
 						} else {
 							sum += d;
 						}
@@ -195,7 +193,7 @@ public:
 					} else if ((inf == 0) && (inf2 != 0)) {
 						d = d1;
 					} else if ((inf == 0) && (inf2 == 0)) {
-						d = MIN(d1, d2);
+						d = std::min(d1, d2);
 					} else if ((inf != 0) && (inf2 != 0)) {
 						continue;  // Go to another cluster
 					}


### PR DESCRIPTION
Some places used custom `MIN` macros but most code was already using `std::min`.

An unused definition of `MAX` was also removed.

This removes a warning when cmake unity builds are done.