### PR TITLE
`TrailedSet::insert()` takes `unsigned int`.

### DIFF
--- a/chuffed/support/sparse_set.h
+++ b/chuffed/support/sparse_set.h
@@ -112,7 +112,7 @@ class TrailedSet : public SparseSet<0> {
 public:
 	TrailedSet(int sz) : SparseSet<0>(sz) {}
 
-	bool insert(int value) {
+	bool insert(unsigned int value) override {
 		// Assumes not FFSET.
 		assert(!elem(value));
 


### PR DESCRIPTION
This fixes the override so that it correctly overrides the virtual rather than overloading it.