### PR TITLE
Fix `-Wreorder-ctor` warnings under clang.

### DIFF
--- a/chuffed/branching/warm-start.h
+++ b/chuffed/branching/warm-start.h
@@ -15,7 +15,7 @@ public:
 			: decs(_decs), pos(0), revive(_revive), init_conflicts(INT_MAX) {}
 
 	WarmStartBrancher(vec<IntVar*> xs, vec<int>& vs, bool _revive = false)
-			: revive(_revive), pos(0), init_conflicts(INT_MAX) {}
+			: pos(0), revive(_revive), init_conflicts(INT_MAX) {}
 
 	bool finished() override {
 		// Already deactivated

--- a/chuffed/globals/EdExplFinder.cpp
+++ b/chuffed/globals/EdExplFinder.cpp
@@ -7,17 +7,17 @@
 #include <iostream>
 
 EdExplFinder::EdExplFinder()
-		: max_char(0),
+		: seq2(nullptr),
+			max_char(0),
+			min_id_cost(0),
 			insertion_cost(nullptr),
 			deletion_cost(nullptr),
 			substitution_cost(nullptr),
-			seq2(nullptr),
-			seqSize(-1),
-			lb(-1),
-			dpMatrix(nullptr),
 			seq1ExcludedCharacters(nullptr),
 			seq2ExcludedCharacters(nullptr),
-			min_id_cost(0) {}
+			dpMatrix(nullptr),
+			seqSize(-1),
+			lb(-1) {}
 
 Clause*
 

--- a/chuffed/globals/minimum_weight_tree.cpp
+++ b/chuffed/globals/minimum_weight_tree.cpp
@@ -328,9 +328,9 @@ public:
 				mw(0),
 				splb(0),
 				explv_sz(0),
-				w(_w),
 				ccs(0),
-				specialtint(0) {
+				specialtint(0),
+				w(_w) {
 		explvp.push();
 		priority = 5;
 		nb_innodes = 0;

--- a/chuffed/globals/value-precede.cpp
+++ b/chuffed/globals/value-precede.cpp
@@ -8,7 +8,7 @@
 class value_precede : public Propagator {
 	// The only propagation which occurs is:
 	struct tag_t {
-		tag_t() : si(0), ti(0), flag(0) {}
+		tag_t() : flag(0), si(0), ti(0) {}
 		tag_t(int _si, int _ti, bool _flag) : flag(_flag), si(_si), ti(_ti) {}
 
 		unsigned flag : 1;
@@ -537,12 +537,12 @@ public:
 
 	seq_precede_inc(vec<IntVar*>& _xs)
 			: xs(_xs),
-				max_def(0),
-				max_val(xs.size()),
 				first(xs.size() + 1, 0),
 				limit(xs.size() + 1, xs.size()),
 				first_val(xs.size(), 0),
-				limit_val(xs.size(), xs.size()) {
+				limit_val(xs.size(), xs.size()),
+				max_val(xs.size()),
+				max_def(0) {
 		int sz = xs.size();
 		priority = 3;
 


### PR DESCRIPTION
This fixes cases where the initialization order was different from the declaration order.

This gets us closer to being able to enable `-Wall`.