### PR TITLE
cumulative_cal: Fix infinite recursion.

### DIFF
--- a/chuffed/globals/cumulativeCalendar.cpp
+++ b/chuffed/globals/cumulativeCalendar.cpp
@@ -1543,7 +1543,7 @@ Clause* CumulativeCalProp::get_reason_for_update(vec<Lit>& expl) {
 void cumulative_cal(vec<IntVar*>& s, vec<IntVar*>& d, vec<IntVar*>& r, IntVar* limit,
 										vec<vec<int> >& cal, vec<int>& taskCal, int rho_in, int resCal_in) {
 	std::list<std::string> opt;
-	cumulative_cal(s, d, r, limit, cal, taskCal, rho_in, resCal_in);
+	cumulative_cal(s, d, r, limit, cal, taskCal, rho_in, resCal_in, opt);
 }
 
 void cumulative_cal(vec<IntVar*>& s, vec<IntVar*>& d, vec<IntVar*>& r, IntVar* limit,


### PR DESCRIPTION
This was a forwarding function to the new version which has an additional parameter. It needs to pass that parameter here though to call the new one rather than just infinitely recurse.