### PR TITLE
Fix call to sat.enqueue in setVal2

### DIFF
--- a/chuffed/vars/bool-view.h
+++ b/chuffed/vars/bool-view.h
@@ -75,7 +75,7 @@ public:
 
 	bool setVal2(bool x, Reason r = nullptr) const {
 		assert(setValNotR(x));
-		sat.enqueue(getLit(x), r.pt);
+		sat.enqueue(getLit(x), r);
 		return (sat.confl == nullptr);
 	}
 


### PR DESCRIPTION
Using the `Clause` pointer `r.pt` here is incorrect because the `Reason` may not actually be a pointer (it just so happens to work on 64-bit platforms because the pointer fills the the whole struct so you end up with a proper copy)

Fixes some WebAssembly crashes.