### PR TITLE
Ignore fixed literals in `warm_start` annotation

### DIFF
--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -408,7 +408,10 @@ void FlatZincSpace::parseSolveAnnWarmStart(AST::Node* elemAnn, BranchGroup* bran
 		}
 		const int sz = std::min(vars->a.size(), vals->a.size());
 		for (int ii = 0; ii < sz; ii++) {
-			decs.push(bv[vars->a[ii]->getBoolVar()].getLit(vals->a[ii]->getBool()));
+			// Ignore constants
+			if (vars->a[ii]->isBoolVar()) {
+				decs.push(bv[vars->a[ii]->getBoolVar()].getLit(vals->a[ii]->getBool()));
+			}
 		}
 	} else {
 		AST::Call* call = elemAnn->getCall("warm_start_int");
@@ -420,6 +423,10 @@ void FlatZincSpace::parseSolveAnnWarmStart(AST::Node* elemAnn, BranchGroup* bran
 		}
 		const int sz = std::min(vars->a.size(), vals->a.size());
 		for (int ii = 0; ii < sz; ii++) {
+			if (vars->a[ii]->isInt()) {
+				// Ignore constants
+				continue;
+			}
 			IntVar* x(iv[vars->a[ii]->getIntVar()]);
 			const int k(vals->a[ii]->getInt());
 			switch (x->getType()) {


### PR DESCRIPTION
Fixes crash when using warm start variable array literal with bool/int literals in it.

Usually MiniZinc doesn't produce this because it'll make an `array [...] of var int: vars = [x, y, 1, 2]` and the FlatZinc parser will create variables even for the fixed values, so it's fine to assume they're always variables. However, the MiniZInc internal Chuffed interface produces these directly which currently crashes.

The other search annotations already ignore fixed constants inside the array literals, so doing this is consistent with them.
