### PR TITLE
Fix up some warnings and issues

### DIFF
--- a/chuffed/globals/disjunctive.cpp
+++ b/chuffed/globals/disjunctive.cpp
@@ -246,12 +246,13 @@ public:
 		}
 
 		// initialise data structures
-		ps_times = (Tint*)malloc(static_cast<size_t>(4 * x.size()) * sizeof(Tint));
-		ps_tasks = (Tint*)malloc(static_cast<size_t>(4 * x.size()) * sizeof(Tint));
-		residual = (Tint*)malloc(x.size() * sizeof(Tint));
+		unsigned tmpsize = x.size();
+		ps_times = (Tint*)malloc(static_cast<size_t>(4 * tmpsize) * sizeof(Tint));
+		ps_tasks = (Tint*)malloc(static_cast<size_t>(4 * tmpsize) * sizeof(Tint));
+		residual = (Tint*)malloc(static_cast<size_t>(tmpsize) * sizeof(Tint));
 
-		ests = (int*)malloc(x.size() * sizeof(int));
-		lets = (int*)malloc(x.size() * sizeof(int));
+		ests = (int*)malloc(static_cast<size_t>(tmpsize) * sizeof(int));
+		lets = (int*)malloc(static_cast<size_t>(tmpsize) * sizeof(int));
 
 		for (int i = 0; i < x.size(); i++) {
 			ests[i] = lets[i] = i;

--- a/chuffed/ldsb/ldsb.cpp
+++ b/chuffed/ldsb/ldsb.cpp
@@ -672,8 +672,9 @@ public:
 		for (int i = 0; i < v.size(); i++) {
 			vars.push(v[i]);
 		}
-		active = (Tchar*)malloc(n * sizeof(Tchar));
-		for (int i = 0; i < n; i++) {
+		unsigned tmp_n = n;
+		active = (Tchar*)malloc(tmp_n * sizeof(Tchar));
+		for (unsigned i = 0; i < n; i++) {
 			active[i] = 1;
 		}
 		for (int i = 0; i < v.size(); i++) {

--- a/chuffed/primitives/linear.cpp
+++ b/chuffed/primitives/linear.cpp
@@ -431,7 +431,7 @@ void int_linear_imp(vec<int>& a, vec<IntVar*>& x, IntRelType t, int c, const Boo
 		}
 		limit += abs(a[i]) * IntVar::max_limit + INT_MAX;
 	}
-	if (limit >= INT64_MAX) {
+	if (limit >= (double)INT64_MAX) {
 		CHUFFED_ERROR("Linear constraint may overflow, not yet supported\n");
 	}
 

--- a/chuffed/support/vec.h
+++ b/chuffed/support/vec.h
@@ -20,7 +20,8 @@ public:
 		}
 	}
 	vec(int _sz, const T& pad) : sz(_sz), cap(sz) {
-		data = sz != 0 ? (T*)malloc(cap * sizeof(T)) : nullptr;
+		unsigned mcap = cap;
+		data = sz != 0 ? (T*)malloc(mcap * sizeof(T)) : nullptr;
 		for (int i = 0; i < sz; i++) {
 			new (&data[i]) T(pad);
 		}

--- a/chuffed/vars/bool-view.h
+++ b/chuffed/vars/bool-view.h
@@ -75,7 +75,7 @@ public:
 
 	bool setVal2(bool x, Reason r = nullptr) const {
 		assert(setValNotR(x));
-		sat.enqueue(getLit(x), r);
+		sat.enqueue(getLit(x), r.pt());
 		return (sat.confl == nullptr);
 	}
 


### PR DESCRIPTION
Addresses warnings like this

```
./chuffed/support/vec.h:24:44: warning: argument 1 range [18446744065119617024, 18446744073709551612] exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   24 |                 data = sz != 0 ? (T*)malloc(mcap * sizeof(T)) : nullptr;
      |                                      ~~~~~~^~~~~~~~~~~~~~~~~~
```

Also I think the big endian fix was missing this change?

```
--- a/src/chuffed/vars/bool-view.h
+++ b/src/chuffed/vars/bool-view.h
@@ -75,7 +75,7 @@ public:
 
        bool setVal2(bool x, Reason r = nullptr) const {
                assert(setValNotR(x));
-               sat.enqueue(getLit(x), r.pt);
+               sat.enqueue(getLit(x), r.pt());
                return (sat.confl == nullptr);
        }
```