### PR TITLE
Spurious % [<UNKNOWN>] output after optimization

### DIFF
--- a/chuffed/flatzinc/fzn-chuffed.cpp
+++ b/chuffed/flatzinc/fzn-chuffed.cpp
@@ -153,7 +153,7 @@ int main(int argc, char** argv) {
 			engine.solve(FlatZinc::s, commandLine);
 		}
 
-		if (engine.status == RES_LUN) {
+		if (engine.status == RES_LUN && !FlatZinc::s->assumptions.empty()) {
 			vec<BoolView> ng;
 			Engine::retrieve_assumption_nogood(ng);
 			std::cout << "% [";


### PR DESCRIPTION
`fzn-chuffed` prints an extra `% [<UNKNOWN>]` line after the `==========` optimality marker.                                                                                                                                    
                                                                                                                                                                                                                                                                                          
To reproduce, create a file `maximize.fzn`:                                                                                                                                                                                                                                                             
```
var 1..10: x :: output_var;                                                                                                                                                                                                                                                             solve maximize x;                                                                                                                                                                                                                                                                       
```
Run:
```
$ fzn-chuffed maximize.fzn                                                                                                                                                                                                                                                              
x = 10;                                                                                                                                                                                                                                                                                 

----------
==========
% [<UNKNOWN>]
```

If I understand correctly, it is reporting th elist of assumptions that aren't satisfied. Here the assumption is simply the inequality added during optimization to ensure that the new candidates are at least as good that the one already found in terms of objective function.
It is probably a bit suprising to report it since it was added internally.

This was found while doing https://github.com/JuliaConstraints/Chuffed.jl/pull/8