### PR TITLE
Adapt assumption interface to MiniZinc's fzn_assume constraint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.5.0)
 project(chuffed CXX C)
 # The version number.
 set(chuffed_VERSION_MAJOR 0)
-set(chuffed_VERSION_MINOR 13)
-set(chuffed_VERSION_PATCH 3)
+set(chuffed_VERSION_MINOR 14)
+set(chuffed_VERSION_PATCH 0)
 
 ### Additional Definitions:
 option(STATIC "compile with the -static linker flag" OFF)

--- a/chuffed/flatzinc/flatzinc.cpp
+++ b/chuffed/flatzinc/flatzinc.cpp
@@ -466,7 +466,8 @@ void FlatZincSpace::parseSolveAnnAux(AST::Node* elemAnn, BranchGroup* branching,
 
 // Entry function for parsing the solve annotation
 void FlatZincSpace::parseSolveAnn(AST::Array* ann) {
-	assumptions.clear();
+	// Note: assumptions are collected from `fzn_assume` constraints during constraint posting
+	// (which happens before the solve item is parsed).
 	int nbNonEmptySearchAnnotations = 0;
 	try {
 		// Parse the search annotation
@@ -531,12 +532,6 @@ void FlatZincSpace::parseSolveAnn(AST::Array* ann, BranchGroup* branching,
 				}
 				if (so.restart_scale_override) {
 					so.restart_scale = static_cast<unsigned int>(args->a[1]->getInt());
-				}
-			} else if (i->isCall("assume")) {
-				AST::Call* call = i->getCall("assume");
-				AST::Array* vars = call->args->getArray();
-				for (auto& ii : vars->a) {
-					assumptions.push(bv[ii->getBoolVar()]);
 				}
 			} else if (i->isCall("seq_search") || i->isCall("warm_start_array")) {
 				// Get the call

--- a/chuffed/flatzinc/fzn-chuffed.cpp
+++ b/chuffed/flatzinc/fzn-chuffed.cpp
@@ -53,6 +53,13 @@ const char* irel_str[] = {" = ", " != ", " <= ", " > "};
 std::string get_bv_string(const BoolView& b, bool tryIntDom) {
 	std::string s;
 
+	// A constant literal uses the reserved constant variable (variable 0), which has no name and
+	// no integer channel; report its value directly to avoid dereferencing invalid channel info.
+	const Lit cl(b.getLit(true));
+	if (var(cl) == 0) {
+		return sat.value(cl) == l_True ? "true" : "false";
+	}
+
 	if (tryIntDom) {
 		// Alternate version: prioritise intvars.
 		const Lit l(b.getLit(true));
@@ -153,15 +160,19 @@ int main(int argc, char** argv) {
 			engine.solve(FlatZinc::s, commandLine);
 		}
 
-		if (engine.status == RES_LUN) {
+		if (engine.status == RES_LUN && FlatZinc::s->assumptions.size() > 0) {
 			vec<BoolView> ng;
 			Engine::retrieve_assumption_nogood(ng);
-			std::cout << "% [";
-			if (ng.size() > 0) {
-				std::cout << get_bv_string(ng[0], so.assump_int);
-				for (unsigned int ii = 1; ii < ng.size(); ii++) {
-					std::cout << ", " << get_bv_string(ng[ii], so.assump_int);
+			std::cout << "%%%mzn-core: [";
+			for (unsigned int ii = 0; ii < ng.size(); ii++) {
+				// The nogood holds the negation of each assumption in the core; report the
+				// assumption itself (the literal that was assumed) so that MiniZinc can map it back.
+				BoolView a(ng[ii]);
+				a.setSign(!a.getSign());
+				if (ii > 0) {
+					std::cout << ", ";
 				}
+				std::cout << get_bv_string(a, so.assump_int);
 			}
 			std::cout << "]" << '\n';
 		}

--- a/chuffed/flatzinc/mznlib/chuffed.mzn
+++ b/chuffed/flatzinc/mznlib/chuffed.mzn
@@ -78,6 +78,3 @@ annotation smallest_largest;
 
 /** @group chuffed.annotations Choose the variable with the largest smallest value in its domain */
 annotation largest_smallest;
-
-/** @group chuffed.annotations annotation for assumption handling. */
-annotation assume(array [int] of var bool);

--- a/chuffed/flatzinc/mznlib/experimental/assume/fzn_assume.mzn
+++ b/chuffed/flatzinc/mznlib/experimental/assume/fzn_assume.mzn
@@ -1,0 +1,2 @@
+predicate chuffed_assume(array [int] of var bool: b);
+predicate fzn_assume(array [int] of var bool: b) = chuffed_assume(b);

--- a/chuffed/flatzinc/registry.cpp
+++ b/chuffed/flatzinc/registry.cpp
@@ -1834,6 +1834,17 @@ void p_bounded_path_new(const ConExpr& ce, AST::Node* /*ann*/) {
 	bounded_path(s, t, vs, es, in, ou, en, ws, w);
 }
 
+void p_assume(const ConExpr& ce, AST::Node* /*ann*/) {
+	// Mark the Boolean variables in the array argument as assumptions. Boolean constants are
+	// handled gracefully by arg2BoolVarArgs (mapped to bv_true / bv_false), so a fixed-false
+	// assumption simply makes the model unsatisfiable rather than crashing.
+	vec<BoolView> bvs;
+	arg2BoolVarArgs(bvs, ce[0]);
+	for (unsigned int i = 0; i < bvs.size(); i++) {
+		s->assumptions.push(bvs[i]);
+	}
+}
+
 class IntPoster {
 public:
 	IntPoster() {
@@ -1907,6 +1918,7 @@ public:
 		registry().add("array_bool_or", &p_array_bool_or);
 		registry().add("bool_clause", &p_array_bool_clause);
 		registry().add("bool_clause_reif", &p_array_bool_clause_reif);
+		registry().add("chuffed_assume", &p_assume);
 		registry().add("array_int_element", &p_array_int_element);
 		registry().add("array_var_int_element", &p_array_var_int_element);
 		registry().add("array_var_int_element_imp", &p_array_var_int_element_imp);


### PR DESCRIPTION
MiniZinc's experimental assumption interface now lowers `assume(...)` to a solver-overridable `fzn_assume` constraint and maps unsatisfiable cores (reported as `%%%mzn-core:` output) back to the original model expressions. Switch Chuffed from the old `assume` solve-annotation to this constraint.